### PR TITLE
Fix syntax error when python3 is default python

### DIFF
--- a/tests/workload/pag.robot
+++ b/tests/workload/pag.robot
@@ -8,7 +8,7 @@ Library           String
 Library           OpenAFSLibrary
 
 *** Variables ***
-${PRINT_GROUPS}    python -c 'import sys; import os; sys.stdout.write("%s\n" % os.getgroups())'
+${PRINT_GROUPS}    python -c 'import sys; import os; sys.stdout.write("%s\\n" % os.getgroups())'
 
 *** Test Cases ***
 Obtain a PAG with pagsh


### PR DESCRIPTION
The python print statement changes to a function call in python3.
Python2.7 includes a print function for compatibility.

Change the statement 'print os.getgroups()' to 'print(os.getgroups())'