### PR TITLE
Fix runtime error in pag test case

### DIFF
--- a/tests/workload/pag.robot
+++ b/tests/workload/pag.robot
@@ -8,7 +8,7 @@ Library           String
 Library           OpenAFSLibrary
 
 *** Variables ***
-${PRINT_GROUPS}    python -c 'import sys; import os; sys.stdout.write("%s\n" % os.getgroups())'
+${PRINT_GROUPS}    python -c 'import sys; import os; sys.stdout.write("%s\\n" % os.getgroups())'
 
 *** Test Cases ***
 Obtain a PAG with pagsh


### PR DESCRIPTION
The escape for the newline in the output string needs an extra escape
character.

Fixes the following error

20200406 21:06:36.390 - INFO - stdin=python -c 'import sys; import os; sys.stdout.write("%s
" % os.getgroups())'
20200406 21:06:36.391 - INFO - code=1
20200406 21:06:36.391 - INFO - stdout=
20200406 21:06:36.391 - INFO - stderr=  File "<string>", line 1
    import sys; import os; sys.stdout.write("%s
                                              ^
SyntaxError: EOL while scanning string literal
20200406 21:06:36.391 - FAIL - Failed to run pagsh!