### PR TITLE
Replace deprecated syntax

### DIFF
--- a/tests/admin/bosserver.robot
+++ b/tests/admin/bosserver.robot
@@ -12,7 +12,7 @@ Suite Teardown    Teardown Users and Groups
 *** Variables ***
 ${VOLUME}      test.basic
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Keywords ***

--- a/tests/admin/volume/backup.robot
+++ b/tests/admin/volume/backup.robot
@@ -9,7 +9,7 @@ Suite Setup       Login  ${AFS_ADMIN}  password=${AFS_ADMIN_PASSWORD}
 Suite Teardown    Logout
 
 *** Variables ***
-${SERVER}        @{AFS_FILESERVERS}[0]
+${SERVER}        ${AFS_FILESERVERS}[0]
 ${PART}          a
 ${OTHERPART}     b
 

--- a/tests/admin/volume/clone.robot
+++ b/tests/admin/volume/clone.robot
@@ -9,7 +9,7 @@ Suite Setup       Login  ${AFS_ADMIN}  password=${AFS_ADMIN_PASSWORD}
 Suite Teardown    Logout
 
 *** Variables ***
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${PART}        a
 ${OTHERPART}   b
 

--- a/tests/admin/volume/create.robot
+++ b/tests/admin/volume/create.robot
@@ -10,7 +10,7 @@ Suite Setup       Login  ${AFS_ADMIN}  password=${AFS_ADMIN_PASSWORD}
 Suite Teardown    Logout
 
 *** Variables ***
-${SERVER}        @{AFS_FILESERVERS}[0]
+${SERVER}        ${AFS_FILESERVERS}[0]
 ${VOLID}         0
 ${PART}          a
 

--- a/tests/admin/volume/dump.robot
+++ b/tests/admin/volume/dump.robot
@@ -11,8 +11,8 @@ Test Teardown      Cleanup Test Volumes
 
 *** Variables ***
 ${VOLUME}      test.dump
-${SERVER}      @{AFS_FILESERVERS}[0]
-${SERVER2}     @{AFS_FILESERVERS}[1]
+${SERVER}      ${AFS_FILESERVERS}[0]
+${SERVER2}     ${AFS_FILESERVERS}[1]
 ${PART}        a
 ${DUMP}        /tmp/test.dump
 ${DIR}         /afs/.${AFS_CELL}/test/${VOLUME}

--- a/tests/admin/volume/move.robot
+++ b/tests/admin/volume/move.robot
@@ -9,8 +9,8 @@ Suite Setup       Login  ${AFS_ADMIN}  password=${AFS_ADMIN_PASSWORD}
 Suite Teardown    Logout
 
 *** Variables ***
-${SERVER1}       @{AFS_FILESERVERS}[0]
-${SERVER2}       @{AFS_FILESERVERS}[1]
+${SERVER1}       ${AFS_FILESERVERS}[0]
+${SERVER2}       ${AFS_FILESERVERS}[1]
 ${PART1}         a
 ${PART2}         b
 
@@ -30,7 +30,7 @@ Move a volume between servers
 
 Avoid creating a rogue volume during move
     [Tags]      requires-multi-fs  bug
-    [Teardown]  Cleanup Rogue    ${vid}   @{AFS_FILESERVERS}[1]
+    [Teardown]  Cleanup Rogue    ${vid}   ${AFS_FILESERVERS}[1]
     ${vid}=            Create volume    xyzzy    ${SERVER2}    ${PART2}    orphan=True
     Command Should Succeed    ${VOS} create -server ${SERVER1} -part ${PART1} -name xyzzy -id ${vid}
     Command Should Fail       ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}

--- a/tests/admin/volume/release.robot
+++ b/tests/admin/volume/release.robot
@@ -9,7 +9,7 @@ Suite Setup       Login  ${AFS_ADMIN}  password=${AFS_ADMIN_PASSWORD}
 Suite Teardown    Logout
 
 *** Variables ***
-${SERVER}        @{AFS_FILESERVERS}[0]
+${SERVER}        ${AFS_FILESERVERS}[0]
 ${PART}          a
 ${OTHERPART}     b
 

--- a/tests/admin/volume/restore.robot
+++ b/tests/admin/volume/restore.robot
@@ -16,7 +16,7 @@ Test Teardown       Cleanup
 *** Variables ***
 ${VOLUME}           test.restore
 ${PART}             a
-${SERVER}           @{AFS_FILESERVERS}[0]
+${SERVER}           ${AFS_FILESERVERS}[0]
 ${DUMP}             /tmp/test.dump
 
 *** Test Cases ***

--- a/tests/workload/basic.robot
+++ b/tests/workload/basic.robot
@@ -12,7 +12,7 @@ Suite Teardown    Teardown
 *** Variables ***
 ${VOLUME}     test.basic
 ${PARTITION}  a
-${SERVER}     @{AFS_FILESERVERS}[0]
+${SERVER}     ${AFS_FILESERVERS}[0]
 ${TESTPATH}   /afs/.${AFS_CELL}/test/${VOLUME}
 ${DIR2}       ${TESTPATH}/dir2
 ${DIR}        ${TESTPATH}/dir

--- a/tests/workload/dir.robot
+++ b/tests/workload/dir.robot
@@ -12,7 +12,7 @@ Suite Teardown    Teardown
 *** Variables ***
 ${VOLUME}      test.basic
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
 ${NAME}        \u20ac\u2020\u2021
 ${FILE}        ${TESTPATH}/${NAME}

--- a/tests/workload/find.robot
+++ b/tests/workload/find.robot
@@ -9,7 +9,7 @@ Suite Teardown    Logout
 *** Variables ***
 ${VOLUME}      test.find
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Keywords ***

--- a/tests/workload/hugefile.robot
+++ b/tests/workload/hugefile.robot
@@ -12,7 +12,7 @@ Suite Teardown    Teardown
 *** Variables ***
 ${VOLUME}      test.basic
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
 ${FILE}        ${TESTPATH}/file
 

--- a/tests/workload/mountpoint.robot
+++ b/tests/workload/mountpoint.robot
@@ -13,7 +13,7 @@ Suite Teardown    Teardown
 ${MTPT}         /afs/.${AFS_CELL}/test/mtpt
 ${VOLUME}     test.mtpt
 ${PARTITION}  a
-${SERVER}     @{AFS_FILESERVERS}[0]
+${SERVER}     ${AFS_FILESERVERS}[0]
 ${TESTPATH}   /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***

--- a/tests/workload/readonly.robot
+++ b/tests/workload/readonly.robot
@@ -9,7 +9,7 @@ Suite Teardown    Teardown Test Suite
 *** Variables ***
 ${VOLUME}      test.ro
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${RWPATH}      /afs/.${AFS_CELL}/test/readonly
 ${ROPATH}      /afs/${AFS_CELL}/test/readonly
 

--- a/tests/workload/stress.robot
+++ b/tests/workload/stress.robot
@@ -10,7 +10,7 @@ Library           OpenAFSLibrary
 *** Variables ***
 ${VOLUME}      test.stress
 ${PARTITION}   a
-${SERVER}      @{AFS_FILESERVERS}[0]
+${SERVER}      ${AFS_FILESERVERS}[0]
 ${RWPATH}      /afs/.${AFS_CELL}/test/stress
 
 *** Keywords ***


### PR DESCRIPTION
Replace @{AFS_FILESERVERS} with ${AFS_FILESERVERS} to remove the warning

"[WARN] Accessing variable items using '@{AFS_FILESERVERS}[0]' syntax is
deprecated. Use '${AFS_FILESERVERS}[0]' instead."