### PR TITLE
sdist build scenario undefined var 'afs_builds'

### DIFF
--- a/cookiecutter/build-scenario/{{cookiecutter.scenario_name}}/molecule.yml
+++ b/cookiecutter/build-scenario/{{cookiecutter.scenario_name}}/molecule.yml
@@ -43,6 +43,7 @@ provisioner:
         afs_bdist_name: "${AFS_BDIST_NAME:-bdist}"
         afs_builds: "${AFS_BUILDS:-../../../../builds}"
 {%- elif cookiecutter.build_target == 'sdist' %}
+        afs_builds: "${AFS_BUILDS:-../../../../builds}"
 {%- elif cookiecutter.build_target == 'packages' %}
         afs_builds: "${AFS_BUILDS:-~/.cache/ansible-openafs/builds}"
 {%- endif %}


### PR DESCRIPTION
running molecule converge against a build sdist scenario produces an
ansible error:

  "msg": "The task includes an option with an undefined variable.
  The error was: 'afs_builds' is undefined