### PR TITLE
Pipe separated format

### DIFF
--- a/tests/__init__.robot
+++ b/tests/__init__.robot
@@ -1,14 +1,16 @@
+*** Comments ***
 # Copyright (c) 2014 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Set Test Run Documentation
+Library         OperatingSystem
+Library         String
+Library         OpenAFSLibrary
+
+Suite Setup     Set Test Run Documentation
 
 *** Keywords ***
 Set Test Run Documentation
-    Set Suite Documentation    OpenAFS Test Run\n\n         append=False    top=True
-    Set Suite Documentation    - *Cell:* ${AFS_CELL}\n      append=True     top=True
-    Set Suite Documentation    - *Realm:* ${KRB_REALM}\n    append=True     top=True
+    Set Suite Documentation    OpenAFS Test Run\n\n    append=False    top=True
+    Set Suite Documentation    - *Cell:* ${AFS_CELL}\n    append=True    top=True
+    Set Suite Documentation    - *Realm:* ${KRB_REALM}\n    append=True    top=True

--- a/tests/__init__.robot
+++ b/tests/__init__.robot
@@ -11,6 +11,6 @@ Suite Setup     Set Test Run Documentation
 
 *** Keywords ***
 Set Test Run Documentation
-    Set Suite Documentation    OpenAFS Test Run\n\n    append=False    top=True
-    Set Suite Documentation    - *Cell:* ${AFS_CELL}\n    append=True    top=True
-    Set Suite Documentation    - *Realm:* ${KRB_REALM}\n    append=True    top=True
+|  | Set Suite Documentation | OpenAFS Test Run\n\n      | append=False | top=True
+|  | Set Suite Documentation | - *Cell:* ${AFS_CELL}\n   | append=True  | top=True
+|  | Set Suite Documentation | - *Realm:* ${KRB_REALM}\n | append=True  | top=True

--- a/tests/admin/bosserver.robot
+++ b/tests/admin/bosserver.robot
@@ -1,42 +1,66 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Bosserver tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup Users and Groups
-Suite Teardown    Teardown Users and Groups
+Documentation       Bosserver tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup Users and Groups
+Suite Teardown      Teardown Users and Groups
 
 *** Variables ***
-${VOLUME}      test.basic
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
+${VOLUME}       test.basic
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
+
+*** Test Cases ***
+List Server Hosts
+    ${output}=    Run    ${BOS} listhosts ${SERVER}
+    Should Contain    ${output}    ${AFS_CELL}
+
+Add a Superuser
+    [Setup]    Superusers Exclude User1
+    Command Should Succeed    ${BOS} adduser ${SERVER} user1
+    Superusers Include User1
+    [Teardown]    Remove Superuser
+
+List Superusers
+    ${output}=    Run    ${BOS} listusers ${SERVER}
+    Should Not Contain    ${output}    user1
+
+Remove a Superuser
+    [Setup]    Add Superuser
+    Superusers Include User1
+    Command Should Succeed    ${BOS} removeuser ${SERVER} user1
+    [Teardown]    Superusers Exclude User1
 
 *** Keywords ***
 Setup Users and Groups
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Command Should Succeed  ${PTS} createuser user1
-    Command Should Succeed  ${PTS} createuser user2
-    Command Should Succeed  ${PTS} creategroup group1 -owner ${AFS_ADMIN}
-    Command Should Succeed  ${PTS} adduser user1 group1
-    Command Should Succeed  ${PTS} adduser user2 group1
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Command Should Succeed    ${PTS} createuser user1
+    Command Should Succeed    ${PTS} createuser user2
+    Command Should Succeed    ${PTS} creategroup group1 -owner ${AFS_ADMIN}
+    Command Should Succeed    ${PTS} adduser user1 group1
+    Command Should Succeed    ${PTS} adduser user2 group1
 
 Teardown Users and Groups
-    Command Should Succeed  ${PTS} delete user1
-    Command Should Succeed  ${PTS} delete user2
-    Command Should Succeed  ${PTS} delete group1
+    Command Should Succeed    ${PTS} delete user1
+    Command Should Succeed    ${PTS} delete user2
+    Command Should Succeed    ${PTS} delete group1
     Logout
 
 Superusers Exclude User1
-    ${output}=  Run           ${BOS} listusers ${SERVER}
-    Should Not Contain        ${output}  user1
+    ${output}=    Run    ${BOS} listusers ${SERVER}
+    Should Not Contain    ${output}    user1
 
 Superusers Include User1
-    ${output}=  Run           ${BOS} listusers ${SERVER}
-    Should Contain            ${output}  user1
+    ${output}=    Run    ${BOS} listusers ${SERVER}
+    Should Contain    ${output}    user1
 
 Add Superuser
     Superusers Exclude User1
@@ -45,24 +69,3 @@ Add Superuser
 Remove Superuser
     Command Should Succeed    ${BOS} removeuser ${SERVER} user1
     Superusers Exclude User1
-
-*** Test Cases ***
-List Server Hosts
-    ${output}=  Run       ${BOS} listhosts ${SERVER}
-    Should Contain        ${output}  ${AFS_CELL}
-
-Add a Superuser
-    [Setup]      Superusers Exclude User1
-    Command Should Succeed    ${BOS} adduser ${SERVER} user1
-    Superusers Include User1
-    [Teardown]   Remove Superuser
-
-List Superusers
-    ${output}=  Run           ${BOS} listusers ${SERVER}
-    Should Not Contain        ${output}  user1
-
-Remove a Superuser
-    [Setup]      Add Superuser
-    Superusers Include User1
-    Command Should Succeed    ${BOS} removeuser ${SERVER} user1
-    [Teardown]   Superusers Exclude User1

--- a/tests/admin/bosserver.robot
+++ b/tests/admin/bosserver.robot
@@ -20,52 +20,52 @@ ${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***
 List Server Hosts
-    ${output}=    Run    ${BOS} listhosts ${SERVER}
-    Should Contain    ${output}    ${AFS_CELL}
+|  | ${output}=     | Run       | ${BOS} listhosts ${SERVER}
+|  | Should Contain | ${output} | ${AFS_CELL}
 
 Add a Superuser
-    [Setup]    Superusers Exclude User1
-    Command Should Succeed    ${BOS} adduser ${SERVER} user1
-    Superusers Include User1
-    [Teardown]    Remove Superuser
+|  | [Setup]                  | Superusers Exclude User1
+|  | Command Should Succeed   | ${BOS} adduser ${SERVER} user1
+|  | Superusers Include User1
+|  | [Teardown]               | Remove Superuser
 
 List Superusers
-    ${output}=    Run    ${BOS} listusers ${SERVER}
-    Should Not Contain    ${output}    user1
+|  | ${output}=         | Run       | ${BOS} listusers ${SERVER}
+|  | Should Not Contain | ${output} | user1
 
 Remove a Superuser
-    [Setup]    Add Superuser
-    Superusers Include User1
-    Command Should Succeed    ${BOS} removeuser ${SERVER} user1
-    [Teardown]    Superusers Exclude User1
+|  | [Setup]                  | Add Superuser
+|  | Superusers Include User1
+|  | Command Should Succeed   | ${BOS} removeuser ${SERVER} user1
+|  | [Teardown]               | Superusers Exclude User1
 
 *** Keywords ***
 Setup Users and Groups
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Command Should Succeed    ${PTS} createuser user1
-    Command Should Succeed    ${PTS} createuser user2
-    Command Should Succeed    ${PTS} creategroup group1 -owner ${AFS_ADMIN}
-    Command Should Succeed    ${PTS} adduser user1 group1
-    Command Should Succeed    ${PTS} adduser user2 group1
+|  | Login                  | ${AFS_ADMIN}                                  | keytab=${AFS_ADMIN_KEYTAB}
+|  | Command Should Succeed | ${PTS} createuser user1
+|  | Command Should Succeed | ${PTS} createuser user2
+|  | Command Should Succeed | ${PTS} creategroup group1 -owner ${AFS_ADMIN}
+|  | Command Should Succeed | ${PTS} adduser user1 group1
+|  | Command Should Succeed | ${PTS} adduser user2 group1
 
 Teardown Users and Groups
-    Command Should Succeed    ${PTS} delete user1
-    Command Should Succeed    ${PTS} delete user2
-    Command Should Succeed    ${PTS} delete group1
-    Logout
+|  | Command Should Succeed | ${PTS} delete user1
+|  | Command Should Succeed | ${PTS} delete user2
+|  | Command Should Succeed | ${PTS} delete group1
+|  | Logout
 
 Superusers Exclude User1
-    ${output}=    Run    ${BOS} listusers ${SERVER}
-    Should Not Contain    ${output}    user1
+|  | ${output}=         | Run       | ${BOS} listusers ${SERVER}
+|  | Should Not Contain | ${output} | user1
 
 Superusers Include User1
-    ${output}=    Run    ${BOS} listusers ${SERVER}
-    Should Contain    ${output}    user1
+|  | ${output}=     | Run       | ${BOS} listusers ${SERVER}
+|  | Should Contain | ${output} | user1
 
 Add Superuser
-    Superusers Exclude User1
-    Command Should Succeed    ${BOS} adduser ${SERVER} user1
+|  | Superusers Exclude User1
+|  | Command Should Succeed   | ${BOS} adduser ${SERVER} user1
 
 Remove Superuser
-    Command Should Succeed    ${BOS} removeuser ${SERVER} user1
-    Superusers Exclude User1
+|  | Command Should Succeed   | ${BOS} removeuser ${SERVER} user1
+|  | Superusers Exclude User1

--- a/tests/admin/ptserver.robot
+++ b/tests/admin/ptserver.robot
@@ -14,134 +14,134 @@ Suite Teardown      Logout
 
 *** Test Cases ***
 Create a User
-    [Setup]    Create User
-    ${output}=    Run    ${PTS} listentries
-    Should Contain    ${output}    user12
-    [Teardown]    Remove User
+|  | [Setup]        | Create User
+|  | ${output}=     | Run         | ${PTS} listentries
+|  | Should Contain | ${output}   | user12
+|  | [Teardown]     | Remove User
 
 Create a Group
-    [Setup]    Create Group
-    ${output}=    Run    ${PTS} membership group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove Group
+|  | [Setup]            | Create Group
+|  | ${output}=         | Run          | ${PTS} membership group12
+|  | Should Not Contain | ${output}    | user12
+|  | [Teardown]         | Remove Group
 
 Add a User to a Group
-    [Setup]    Create User and Group
-    Command Should Succeed    ${PTS} adduser user12 group12
-    ${output}=    Run    ${PTS} membership group12
-    Should Contain    ${output}    user12
-    Command Should Succeed    ${PTS} removeuser user12 group12
-    ${output}=    Run    ${PTS} membership group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove User and Group
+|  | [Setup]                | Create User and Group
+|  | Command Should Succeed | ${PTS} adduser user12 group12
+|  | ${output}=             | Run                              | ${PTS} membership group12
+|  | Should Contain         | ${output}                        | user12
+|  | Command Should Succeed | ${PTS} removeuser user12 group12
+|  | ${output}=             | Run                              | ${PTS} membership group12
+|  | Should Not Contain     | ${output}                        | user12
+|  | [Teardown]             | Remove User and Group
 
 Chown a Group
-    [Setup]    Create User and Group
-    Command Should Succeed    ${PTS} chown group12 user12
-    ${output}=    Run    ${PTS} examine group12
-    Should Contain    ${output}    owner: user12
-    [Teardown]    Remove User and Group
+|  | [Setup]                | Create User and Group
+|  | Command Should Succeed | ${PTS} chown group12 user12
+|  | ${output}=             | Run                         | ${PTS} examine group12
+|  | Should Contain         | ${output}                   | owner: user12
+|  | [Teardown]             | Remove User and Group
 
 Get User Membership
-    [Setup]    Create User
-    ${output}=    Run    ${PTS} membership user12
-    Should Not Contain    ${output}    group12
-    [Teardown]    Remove User
+|  | [Setup]            | Create User
+|  | ${output}=         | Run         | ${PTS} membership user12
+|  | Should Not Contain | ${output}   | group12
+|  | [Teardown]         | Remove User
 
 Get Group Membership
-    [Setup]    Create Group
-    ${output}=    Run    ${PTS} membership group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove Group
+|  | [Setup]            | Create Group
+|  | ${output}=         | Run          | ${PTS} membership group12
+|  | Should Not Contain | ${output}    | user12
+|  | [Teardown]         | Remove Group
 
 Examine a User
-    [Setup]    Create User
-    ${output}=    Run    ${PTS} examine user12
-    Should Not Contain    ${output}    group12
-    [Teardown]    Remove User
+|  | [Setup]            | Create User
+|  | ${output}=         | Run         | ${PTS} examine user12
+|  | Should Not Contain | ${output}   | group12
+|  | [Teardown]         | Remove User
 
 Examine a Group
-    [Setup]    Create Group
-    ${output}=    Run    ${PTS} examine group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove Group
+|  | [Setup]            | Create Group
+|  | ${output}=         | Run          | ${PTS} examine group12
+|  | Should Not Contain | ${output}    | user12
+|  | [Teardown]         | Remove Group
 
 Remove a User from a Group
-    [Setup]    Create User and Group
-    Command Should Succeed    ${PTS} adduser user12 group12
-    ${output}=    Run    ${PTS} membership group12
-    Should Contain    ${output}    user12
-    Command Should Succeed    ${PTS} removeuser user12 group12
-    ${output}=    Run    ${PTS} membership group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove User and Group
+|  | [Setup]                | Create User and Group
+|  | Command Should Succeed | ${PTS} adduser user12 group12
+|  | ${output}=             | Run                              | ${PTS} membership group12
+|  | Should Contain         | ${output}                        | user12
+|  | Command Should Succeed | ${PTS} removeuser user12 group12
+|  | ${output}=             | Run                              | ${PTS} membership group12
+|  | Should Not Contain     | ${output}                        | user12
+|  | [Teardown]             | Remove User and Group
 
 List Groups a User Owns
-    [Setup]    Create User
-    ${output}=    Run    ${PTS} listowned user12
-    Should Not Contain    ${output}    group12
-    [Teardown]    Remove User
+|  | [Setup]            | Create User
+|  | ${output}=         | Run         | ${PTS} listowned user12
+|  | Should Not Contain | ${output}   | group12
+|  | [Teardown]         | Remove User
 
 Set and List Maxuser
-    ${output}=    Run    ${PTS} setmax -group -500 -user 1000
-    ${output}=    Run    ${PTS} listmax
-    Should Be Equal    ${output}    Max user id is 1000 and max group id is -500.
+|  | ${output}=      | Run       | ${PTS} setmax -group -500 -user 1000
+|  | ${output}=      | Run       | ${PTS} listmax
+|  | Should Be Equal | ${output} | Max user id is 1000 and max group id is -500.
 
 Set Fields on a User
-    [Setup]    Create User
-    Command Should Succeed    ${PTS} setfields user12 -groupquota 56
-    ${output}=    Run    ${PTS} examine user12
-    Should Contain    ${output}    group quota: 56
-    [Teardown]    Remove User
+|  | [Setup]                | Create User
+|  | Command Should Succeed | ${PTS} setfields user12 -groupquota 56
+|  | ${output}=             | Run                                    | ${PTS} examine user12
+|  | Should Contain         | ${output}                              | group quota: 56
+|  | [Teardown]             | Remove User
 
 Delete a Group
-    [Setup]    Create Group
-    ${output}=    Run    ${PTS} membership group12
-    Should Not Contain    ${output}    user12
-    [Teardown]    Remove Group
+|  | [Setup]            | Create Group
+|  | ${output}=         | Run          | ${PTS} membership group12
+|  | Should Not Contain | ${output}    | user12
+|  | [Teardown]         | Remove Group
 
 Delete a User
-    [Setup]    Create User
-    ${output}=    Run    ${PTS} membership user12
-    Should Not Contain    ${output}    group12
-    [Teardown]    Remove User
+|  | [Setup]            | Create User
+|  | ${output}=         | Run         | ${PTS} membership user12
+|  | Should Not Contain | ${output}   | group12
+|  | [Teardown]         | Remove User
 
 *** Keywords ***
 Teardown Users and Groups
-    Command Should Succeed    ${PTS} delete user12
-    Command Should Succeed    ${PTS} delete group12
+|  | Command Should Succeed | ${PTS} delete user12
+|  | Command Should Succeed | ${PTS} delete group12
 
 Create User and Group
-    ${output}=    Run    ${PTS} listentries -users -groups
-    Should Not Contain    ${output}    user12
-    Should Not Contain    ${output}    group12
-    Command Should Succeed    ${PTS} createuser user12
-    Command Should Succeed    ${PTS} creategroup group12 -owner ${AFS_ADMIN}
-    ${output}=    Run    ${PTS} listentries -users -groups
+|  | ${output}=             | Run                                            | ${PTS} listentries -users -groups
+|  | Should Not Contain     | ${output}                                      | user12
+|  | Should Not Contain     | ${output}                                      | group12
+|  | Command Should Succeed | ${PTS} createuser user12
+|  | Command Should Succeed | ${PTS} creategroup group12 -owner ${AFS_ADMIN}
+|  | ${output}=             | Run                                            | ${PTS} listentries -users -groups
 
 Remove User and Group
-    Command Should Succeed    ${PTS} delete group12
-    Command Should Succeed    ${PTS} delete user12
-    ${output}=    Run    ${PTS} listentries -users -groups
-    Should Not Contain    ${output}    user12
-    Should Not Contain    ${output}    group12
+|  | Command Should Succeed | ${PTS} delete group12
+|  | Command Should Succeed | ${PTS} delete user12
+|  | ${output}=             | Run                   | ${PTS} listentries -users -groups
+|  | Should Not Contain     | ${output}             | user12
+|  | Should Not Contain     | ${output}             | group12
 
 Create User
-    ${output}=    Run    ${PTS} listentries
-    Should Not Contain    ${output}    user12
-    Command Should Succeed    ${PTS} createuser user12
+|  | ${output}=             | Run                      | ${PTS} listentries
+|  | Should Not Contain     | ${output}                | user12
+|  | Command Should Succeed | ${PTS} createuser user12
 
 Remove User
-    Command Should Succeed    ${PTS} delete user12
-    ${output}=    Run    ${PTS} listentries
-    Should Not Contain    ${output}    user12
+|  | Command Should Succeed | ${PTS} delete user12
+|  | ${output}=             | Run                  | ${PTS} listentries
+|  | Should Not Contain     | ${output}            | user12
 
 Create Group
-    ${output}=    Run    ${PTS} listentries
-    Should Not Contain    ${output}    group12
-    Command Should Succeed    ${PTS} creategroup group12
+|  | ${output}=             | Run                        | ${PTS} listentries
+|  | Should Not Contain     | ${output}                  | group12
+|  | Command Should Succeed | ${PTS} creategroup group12
 
 Remove Group
-    Command Should Succeed    ${PTS} delete group12
-    ${output}=    Run    ${PTS} listentries
-    Should Not Contain    ${output}    group12
+|  | Command Should Succeed | ${PTS} delete group12
+|  | ${output}=             | Run                   | ${PTS} listentries
+|  | Should Not Contain     | ${output}             | group12

--- a/tests/admin/ptserver.robot
+++ b/tests/admin/ptserver.robot
@@ -1,144 +1,147 @@
+*** Comments ***
 # Copyright #(c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Ptserver tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Documentation       Ptserver tests
 
-*** Keywords ***
-Teardown Users and Groups
-    Command Should Succeed  ${PTS} delete user12
-    Command Should Succeed  ${PTS} delete group12
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
 
-Create User and Group
-     ${output}=  Run         ${PTS} listentries -users -groups
-     Should Not Contain      ${output}  user12
-     Should Not Contain      ${output}  group12
-     Command Should Succeed  ${PTS} createuser user12
-     Command Should Succeed  ${PTS} creategroup group12 -owner ${AFS_ADMIN}
-     ${output}=  Run         ${PTS} listentries -users -groups
-
-Remove User and Group
-     Command Should Succeed  ${PTS} delete group12
-     Command Should Succeed  ${PTS} delete user12
-     ${output}=  Run         ${PTS} listentries -users -groups
-     Should Not Contain      ${output}  user12
-     Should Not Contain      ${output}  group12
-
-Create User
-     ${output}=  Run         ${PTS} listentries
-     Should Not Contain      ${output}  user12
-     Command Should Succeed  ${PTS} createuser user12
-
-Remove User
-     Command Should Succeed  ${PTS} delete user12
-     ${output}=  Run         ${PTS} listentries
-     Should Not Contain      ${output}  user12
-
-Create Group
-     ${output}=  Run         ${PTS} listentries
-     Should Not Contain      ${output}  group12
-     Command Should Succeed  ${PTS} creategroup group12
-
-Remove Group
-     Command Should Succeed  ${PTS} delete group12
-     ${output}=  Run         ${PTS} listentries
-     Should Not Contain      ${output}  group12
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Test Cases ***
 Create a User
-    [Setup]  Create User
-    ${output}=  Run         ${PTS} listentries
-    Should Contain          ${output}  user12
-    [Teardown]  Remove User
+    [Setup]    Create User
+    ${output}=    Run    ${PTS} listentries
+    Should Contain    ${output}    user12
+    [Teardown]    Remove User
 
 Create a Group
-    [Setup]  Create Group
-    ${output}=  Run         ${PTS} membership group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove Group
+    [Setup]    Create Group
+    ${output}=    Run    ${PTS} membership group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove Group
 
 Add a User to a Group
-    [Setup]  Create User and Group
-    Command Should Succeed  ${PTS} adduser user12 group12
-    ${output}=  Run         ${PTS} membership group12
-    Should Contain          ${output}  user12
-    Command Should Succeed  ${PTS} removeuser user12 group12
-    ${output}=  Run         ${PTS} membership group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove User and Group
+    [Setup]    Create User and Group
+    Command Should Succeed    ${PTS} adduser user12 group12
+    ${output}=    Run    ${PTS} membership group12
+    Should Contain    ${output}    user12
+    Command Should Succeed    ${PTS} removeuser user12 group12
+    ${output}=    Run    ${PTS} membership group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove User and Group
 
 Chown a Group
-    [Setup]  Create User and Group
-    Command Should Succeed  ${PTS} chown group12 user12
-    ${output}=  Run         ${PTS} examine group12
-    Should Contain          ${output}  owner: user12
-    [Teardown]  Remove User and Group
+    [Setup]    Create User and Group
+    Command Should Succeed    ${PTS} chown group12 user12
+    ${output}=    Run    ${PTS} examine group12
+    Should Contain    ${output}    owner: user12
+    [Teardown]    Remove User and Group
 
 Get User Membership
-    [Setup]  Create User
-    ${output}=  Run         ${PTS} membership user12
-    Should Not Contain      ${output}  group12
-    [Teardown]  Remove User
+    [Setup]    Create User
+    ${output}=    Run    ${PTS} membership user12
+    Should Not Contain    ${output}    group12
+    [Teardown]    Remove User
 
 Get Group Membership
-    [Setup]  Create Group
-    ${output}=  Run         ${PTS} membership group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove Group
+    [Setup]    Create Group
+    ${output}=    Run    ${PTS} membership group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove Group
 
 Examine a User
-    [Setup]  Create User
-    ${output}=  Run         ${PTS} examine user12
-    Should Not Contain      ${output}  group12
-    [Teardown]  Remove User
+    [Setup]    Create User
+    ${output}=    Run    ${PTS} examine user12
+    Should Not Contain    ${output}    group12
+    [Teardown]    Remove User
 
 Examine a Group
-    [Setup]  Create Group
-    ${output}=  Run         ${PTS} examine group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove Group
+    [Setup]    Create Group
+    ${output}=    Run    ${PTS} examine group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove Group
 
 Remove a User from a Group
-    [Setup]  Create User and Group
-    Command Should Succeed  ${PTS} adduser user12 group12
-    ${output}=  Run         ${PTS} membership group12
-    Should Contain          ${output}  user12
-    Command Should Succeed  ${PTS} removeuser user12 group12
-    ${output}=  Run         ${PTS} membership group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove User and Group
+    [Setup]    Create User and Group
+    Command Should Succeed    ${PTS} adduser user12 group12
+    ${output}=    Run    ${PTS} membership group12
+    Should Contain    ${output}    user12
+    Command Should Succeed    ${PTS} removeuser user12 group12
+    ${output}=    Run    ${PTS} membership group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove User and Group
 
 List Groups a User Owns
-    [Setup]  Create User
-    ${output}=  Run         ${PTS} listowned user12
-    Should Not Contain      ${output}  group12
-    [Teardown]  Remove User
+    [Setup]    Create User
+    ${output}=    Run    ${PTS} listowned user12
+    Should Not Contain    ${output}    group12
+    [Teardown]    Remove User
 
 Set and List Maxuser
-    ${output}=  Run          ${PTS} setmax -group -500 -user 1000
-    ${output}=  Run          ${PTS} listmax
-    Should Be Equal          ${output}  Max user id is 1000 and max group id is -500.
+    ${output}=    Run    ${PTS} setmax -group -500 -user 1000
+    ${output}=    Run    ${PTS} listmax
+    Should Be Equal    ${output}    Max user id is 1000 and max group id is -500.
 
 Set Fields on a User
-    [Setup]  Create User
-    Command Should Succeed  ${PTS} setfields user12 -groupquota 56
-    ${output}=  Run         ${PTS} examine user12
-    Should Contain          ${output}  group quota: 56
-    [Teardown]  Remove User
+    [Setup]    Create User
+    Command Should Succeed    ${PTS} setfields user12 -groupquota 56
+    ${output}=    Run    ${PTS} examine user12
+    Should Contain    ${output}    group quota: 56
+    [Teardown]    Remove User
 
 Delete a Group
-    [Setup]  Create Group
-    ${output}=  Run         ${PTS} membership group12
-    Should Not Contain      ${output}  user12
-    [Teardown]  Remove Group
+    [Setup]    Create Group
+    ${output}=    Run    ${PTS} membership group12
+    Should Not Contain    ${output}    user12
+    [Teardown]    Remove Group
 
 Delete a User
-    [Setup]  Create User
-    ${output}=  Run         ${PTS} membership user12
-    Should Not Contain      ${output}  group12
-    [Teardown]  Remove User
+    [Setup]    Create User
+    ${output}=    Run    ${PTS} membership user12
+    Should Not Contain    ${output}    group12
+    [Teardown]    Remove User
+
+*** Keywords ***
+Teardown Users and Groups
+    Command Should Succeed    ${PTS} delete user12
+    Command Should Succeed    ${PTS} delete group12
+
+Create User and Group
+    ${output}=    Run    ${PTS} listentries -users -groups
+    Should Not Contain    ${output}    user12
+    Should Not Contain    ${output}    group12
+    Command Should Succeed    ${PTS} createuser user12
+    Command Should Succeed    ${PTS} creategroup group12 -owner ${AFS_ADMIN}
+    ${output}=    Run    ${PTS} listentries -users -groups
+
+Remove User and Group
+    Command Should Succeed    ${PTS} delete group12
+    Command Should Succeed    ${PTS} delete user12
+    ${output}=    Run    ${PTS} listentries -users -groups
+    Should Not Contain    ${output}    user12
+    Should Not Contain    ${output}    group12
+
+Create User
+    ${output}=    Run    ${PTS} listentries
+    Should Not Contain    ${output}    user12
+    Command Should Succeed    ${PTS} createuser user12
+
+Remove User
+    Command Should Succeed    ${PTS} delete user12
+    ${output}=    Run    ${PTS} listentries
+    Should Not Contain    ${output}    user12
+
+Create Group
+    ${output}=    Run    ${PTS} listentries
+    Should Not Contain    ${output}    group12
+    Command Should Succeed    ${PTS} creategroup group12
+
+Remove Group
+    Command Should Succeed    ${PTS} delete group12
+    ${output}=    Run    ${PTS} listentries
+    Should Not Contain    ${output}    group12

--- a/tests/admin/volume/backup.robot
+++ b/tests/admin/volume/backup.robot
@@ -1,40 +1,41 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${SERVER}        ${AFS_FILESERVER_A}
-${PART}          a
-${OTHERPART}     b
-
+${SERVER}       ${AFS_FILESERVER_A}
+${PART}         a
+${OTHERPART}    b
 
 *** Test Cases ***
 Create a Backup Volume
-    [Setup]     Create Volume   xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume   xyzzy
-    ${output}=  Run           ${VOS} backup xyzzy
-    Should Contain            ${output}  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
+    ${output}=    Run    ${VOS} backup xyzzy
+    Should Contain    ${output}    xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Avoid creating a rogue volume during backup
-    [Tags]         rogue-avoidance
-    [Teardown]     Run Keywords    Remove volume    xyzzz
-    ...            AND             Cleanup Rogue    ${vid_bk}
+    [Tags]    rogue-avoidance
     Set test variable    ${vid}    0
     Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzy
     Command Should Succeed    ${VOS} remove ${SERVER} ${PART} -id xyzzy
-    ${vid_bk}=        Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
-    ${vid}=           Evaluate    ${vid_bk} - 2
+    ${vid_bk}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
+    ${vid}=    Evaluate    ${vid_bk} - 2
     Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzz -id ${vid}
-    Command Should Fail       ${VOS} backup xyzzz
+    Command Should Fail    ${VOS} backup xyzzz
+    [Teardown]    Run Keywords    Remove volume    xyzzz
+    ...    AND    Cleanup Rogue    ${vid_bk}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]     ${vid}
-    Remove volume   ${vid}    server=${SERVER}
-    Remove volume   ${vid}    server=${SERVER}    zap=True
+    [Arguments]    ${vid}
+    Remove volume    ${vid}    server=${SERVER}
+    Remove volume    ${vid}    server=${SERVER}    zap=True

--- a/tests/admin/volume/backup.robot
+++ b/tests/admin/volume/backup.robot
@@ -17,25 +17,25 @@ ${OTHERPART}    b
 
 *** Test Cases ***
 Create a Backup Volume
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    ${output}=    Run    ${VOS} backup xyzzy
-    Should Contain    ${output}    xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]        | Create Volume | xyzzy               | ${SERVER} | ${PART}
+|  | ${output}=     | Run           | ${VOS} backup xyzzy
+|  | Should Contain | ${output}     | xyzzy
+|  | [Teardown]     | Remove Volume | xyzzy
 
 Avoid creating a rogue volume during backup
-    [Tags]    rogue-avoidance
-    Set test variable    ${vid}    0
-    Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzy
-    Command Should Succeed    ${VOS} remove ${SERVER} ${PART} -id xyzzy
-    ${vid_bk}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
-    ${vid}=    Evaluate    ${vid_bk} - 2
-    Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzz -id ${vid}
-    Command Should Fail    ${VOS} backup xyzzz
-    [Teardown]    Run Keywords    Remove volume    xyzzz
-    ...    AND    Cleanup Rogue    ${vid_bk}
+|  | [Tags]                 | rogue-avoidance
+|  | Set test variable      | ${vid}                                           | 0
+|  | Command Should Succeed | ${VOS} create ${SERVER} ${PART} xyzzy
+|  | Command Should Succeed | ${VOS} remove ${SERVER} ${PART} -id xyzzy
+|  | ${vid_bk}=             | Create volume                                    | xyzzy         | ${SERVER} | ${OTHERPART} | orphan=True
+|  | ${vid}=                | Evaluate                                         | ${vid_bk} - 2
+|  | Command Should Succeed | ${VOS} create ${SERVER} ${PART} xyzzz -id ${vid}
+|  | Command Should Fail    | ${VOS} backup xyzzz
+|  | [Teardown]             | Run Keywords                                     | Remove volume | xyzzz
+|  | ...                    | AND                                              | Cleanup Rogue | ${vid_bk}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]    ${vid}
-    Remove volume    ${vid}    server=${SERVER}
-    Remove volume    ${vid}    server=${SERVER}    zap=True
+|  | [Arguments]   | ${vid}
+|  | Remove volume | ${vid} | server=${SERVER}
+|  | Remove volume | ${vid} | server=${SERVER} | zap=True

--- a/tests/admin/volume/clone.robot
+++ b/tests/admin/volume/clone.robot
@@ -1,30 +1,32 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${SERVER}      ${AFS_FILESERVER_A}
-${PART}        a
-${OTHERPART}   b
+${SERVER}       ${AFS_FILESERVER_A}
+${PART}         a
+${OTHERPART}    b
 
 *** Test Cases ***
 Avoid creating a rogue volume during clone
-    [Tags]         rogue-avoidance
-    [Teardown]     Run Keywords    Remove volume    xyzzz
-    ...            AND             Cleanup Rogue    ${vid}
+    [Tags]    rogue-avoidance
     Set test variable    ${vid}    0
-    ${vid}=        Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
+    ${vid}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
     Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzz
-    Command Should Fail       ${VOS} clone xyzzz ${SERVER} ${PART} -toid ${vid}
+    Command Should Fail    ${VOS} clone xyzzz ${SERVER} ${PART} -toid ${vid}
+    [Teardown]    Run Keywords    Remove volume    xyzzz
+    ...    AND    Cleanup Rogue    ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]     ${vid}
-    Remove volume   ${vid}    server=${SERVER}
-    Remove volume   ${vid}    server=${SERVER}    zap=True
+    [Arguments]    ${vid}
+    Remove volume    ${vid}    server=${SERVER}
+    Remove volume    ${vid}    server=${SERVER}    zap=True

--- a/tests/admin/volume/clone.robot
+++ b/tests/admin/volume/clone.robot
@@ -17,16 +17,16 @@ ${OTHERPART}    b
 
 *** Test Cases ***
 Avoid creating a rogue volume during clone
-    [Tags]    rogue-avoidance
-    Set test variable    ${vid}    0
-    ${vid}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
-    Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzz
-    Command Should Fail    ${VOS} clone xyzzz ${SERVER} ${PART} -toid ${vid}
-    [Teardown]    Run Keywords    Remove volume    xyzzz
-    ...    AND    Cleanup Rogue    ${vid}
+|  | [Tags]                 | rogue-avoidance
+|  | Set test variable      | ${vid}                                            | 0
+|  | ${vid}=                | Create volume                                     | xyzzy         | ${SERVER} | ${OTHERPART} | orphan=True
+|  | Command Should Succeed | ${VOS} create ${SERVER} ${PART} xyzzz
+|  | Command Should Fail    | ${VOS} clone xyzzz ${SERVER} ${PART} -toid ${vid}
+|  | [Teardown]             | Run Keywords                                      | Remove volume | xyzzz
+|  | ...                    | AND                                               | Cleanup Rogue | ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]    ${vid}
-    Remove volume    ${vid}    server=${SERVER}
-    Remove volume    ${vid}    server=${SERVER}    zap=True
+|  | [Arguments]   | ${vid}
+|  | Remove volume | ${vid} | server=${SERVER}
+|  | Remove volume | ${vid} | server=${SERVER} | zap=True

--- a/tests/admin/volume/create.robot
+++ b/tests/admin/volume/create.robot
@@ -19,64 +19,64 @@ ${PART}         a
 
 *** Test Cases ***
 Create a Volume
-    Volume Should Not Exist    xyzzy
-    Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzy
-    Volume Should Exist    xyzzy
-    Volume Location Matches    xyzzy    server=${SERVER}    part=${PART}
-    [Teardown]    Remove Volume    xyzzy
+|  | Volume Should Not Exist | xyzzy
+|  | Command Should Succeed  | ${VOS} create ${SERVER} ${PART} xyzzy
+|  | Volume Should Exist     | xyzzy
+|  | Volume Location Matches | xyzzy                                 | server=${SERVER} | part=${PART}
+|  | [Teardown]              | Remove Volume                         | xyzzy
 
 Add a Replication Site
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
-    Command Should Succeed    ${VOS} remsite ${SERVER} a xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]                | Create Volume                    | xyzzy | ${SERVER} | ${PART}
+|  | Command Should Succeed | ${VOS} addsite ${SERVER} a xyzzy
+|  | Command Should Succeed | ${VOS} remsite ${SERVER} a xyzzy
+|  | [Teardown]             | Remove Volume                    | xyzzy
 
 Remove a Replication Site
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
-    Command Should Succeed    ${VOS} release xyzzy
-    Command Should Succeed    ${VOS} remsite ${SERVER} a xyzzy
-    Volume Should Exist    xyzzy.readonly
-    [Teardown]    Run Keywords    Command Should Succeed    ${VOS} remove ${SERVER} a xyzzy.readonly
-    ...    AND    Remove Volume    xyzzy
+|  | [Setup]                | Create Volume                    | xyzzy                  | ${SERVER}                                | ${PART}
+|  | Command Should Succeed | ${VOS} addsite ${SERVER} a xyzzy
+|  | Command Should Succeed | ${VOS} release xyzzy
+|  | Command Should Succeed | ${VOS} remsite ${SERVER} a xyzzy
+|  | Volume Should Exist    | xyzzy.readonly
+|  | [Teardown]             | Run Keywords                     | Command Should Succeed | ${VOS} remove ${SERVER} a xyzzy.readonly
+|  | ...                    | AND                              | Remove Volume          | xyzzy
 
 Remove a Replicated Volume
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
-    Command Should Succeed    ${VOS} release xyzzy
-    Command Should Succeed    ${VOS} remove ${SERVER} a -id xyzzy.readonly
-    Command Should Succeed    ${VOS} remove -id xyzzy
-    Volume Should Not Exist    xyzzy.readonly
-    Volume Should Not Exist    xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]                 | Create Volume                                | xyzzy | ${SERVER} | ${PART}
+|  | Command Should Succeed  | ${VOS} addsite ${SERVER} a xyzzy
+|  | Command Should Succeed  | ${VOS} release xyzzy
+|  | Command Should Succeed  | ${VOS} remove ${SERVER} a -id xyzzy.readonly
+|  | Command Should Succeed  | ${VOS} remove -id xyzzy
+|  | Volume Should Not Exist | xyzzy.readonly
+|  | Volume Should Not Exist | xyzzy
+|  | [Teardown]              | Remove Volume                                | xyzzy
 
 Display Volume Header Information
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    ${output}=    Run    ${VOS} listvol ${SERVER} a
-    Should Contain    ${output}    xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]        | Create Volume | xyzzy                      | ${SERVER} | ${PART}
+|  | ${output}=     | Run           | ${VOS} listvol ${SERVER} a
+|  | Should Contain | ${output}     | xyzzy
+|  | [Teardown]     | Remove Volume | xyzzy
 
 Display VLDB Information
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    ${output}=    Run    ${VOS} listvldb -server ${SERVER}
-    Should Contain    ${output}    xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]        | Create Volume | xyzzy                             | ${SERVER} | ${PART}
+|  | ${output}=     | Run           | ${VOS} listvldb -server ${SERVER}
+|  | Should Contain | ${output}     | xyzzy
+|  | [Teardown]     | Remove Volume | xyzzy
 
 Display Header and VLDB Information
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    ${output}=    Run    ${VOS} examine xyzzy
-    Should Contain    ${output}    xyzzy
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]        | Create Volume | xyzzy                | ${SERVER} | ${PART}
+|  | ${output}=     | Run           | ${VOS} examine xyzzy
+|  | Should Contain | ${output}     | xyzzy
+|  | [Teardown]     | Remove Volume | xyzzy
 
 Avoid creating a rogue volume during create
-    [Tags]    rogue-avoidance
-    Set test variable    ${vid}    0
-    ${vid}=    Create volume    xyzzy    ${SERVER}    a    orphan=True
-    Command Should Fail    ${VOS} create -server ${SERVER} -part b -name xyzzy -id ${vid}
-    [Teardown]    Cleanup Rogue    ${vid}
+|  | [Tags]              | rogue-avoidance
+|  | Set test variable   | ${vid}                                                         | 0
+|  | ${vid}=             | Create volume                                                  | xyzzy  | ${SERVER} | a | orphan=True
+|  | Command Should Fail | ${VOS} create -server ${SERVER} -part b -name xyzzy -id ${vid}
+|  | [Teardown]          | Cleanup Rogue                                                  | ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]    ${vid}
-    Remove volume    ${vid}    server=${SERVER}
-    Remove volume    ${vid}    server=${SERVER}    zap=True
+|  | [Arguments]   | ${vid}
+|  | Remove volume | ${vid} | server=${SERVER}
+|  | Remove volume | ${vid} | server=${SERVER} | zap=True

--- a/tests/admin/volume/create.robot
+++ b/tests/admin/volume/create.robot
@@ -1,80 +1,82 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Volserver/vlserver tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Documentation       Volserver/vlserver tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${SERVER}        ${AFS_FILESERVER_A}
-${VOLID}         0
-${PART}          a
-
+${SERVER}       ${AFS_FILESERVER_A}
+${VOLID}        0
+${PART}         a
 
 *** Test Cases ***
 Create a Volume
-    [Teardown]  Remove Volume  xyzzy
-    Volume Should Not Exist  xyzzy
-    Command Should Succeed   ${VOS} create ${SERVER} ${PART} xyzzy
-    Volume Should Exist      xyzzy
-    Volume Location Matches  xyzzy  server=${SERVER}  part=${PART}
+    Volume Should Not Exist    xyzzy
+    Command Should Succeed    ${VOS} create ${SERVER} ${PART} xyzzy
+    Volume Should Exist    xyzzy
+    Volume Location Matches    xyzzy    server=${SERVER}    part=${PART}
+    [Teardown]    Remove Volume    xyzzy
 
 Add a Replication Site
-    [Setup]     Create Volume  xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
     Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
     Command Should Succeed    ${VOS} remsite ${SERVER} a xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Remove a Replication Site
-    [Setup]     Create Volume  xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Run Keywords   Command Should Succeed  ${VOS} remove ${SERVER} a xyzzy.readonly
-    ...         AND            Remove Volume  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
     Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
     Command Should Succeed    ${VOS} release xyzzy
     Command Should Succeed    ${VOS} remsite ${SERVER} a xyzzy
-    Volume Should Exist       xyzzy.readonly
+    Volume Should Exist    xyzzy.readonly
+    [Teardown]    Run Keywords    Command Should Succeed    ${VOS} remove ${SERVER} a xyzzy.readonly
+    ...    AND    Remove Volume    xyzzy
 
 Remove a Replicated Volume
-    [Setup]     Create Volume   xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume   xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
     Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzy
     Command Should Succeed    ${VOS} release xyzzy
     Command Should Succeed    ${VOS} remove ${SERVER} a -id xyzzy.readonly
     Command Should Succeed    ${VOS} remove -id xyzzy
-    Volume Should Not Exist   xyzzy.readonly
-    Volume Should Not Exist   xyzzy
+    Volume Should Not Exist    xyzzy.readonly
+    Volume Should Not Exist    xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Display Volume Header Information
-    [Setup]     Create Volume   xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume   xyzzy
-    ${output}=  Run           ${VOS} listvol ${SERVER} a
-    Should Contain            ${output}  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
+    ${output}=    Run    ${VOS} listvol ${SERVER} a
+    Should Contain    ${output}    xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Display VLDB Information
-    [Setup]     Create Volume   xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume   xyzzy
-    ${output}=  Run             ${VOS} listvldb -server ${SERVER}
-    Should Contain              ${output}  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
+    ${output}=    Run    ${VOS} listvldb -server ${SERVER}
+    Should Contain    ${output}    xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Display Header and VLDB Information
-    [Setup]     Create Volume   xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume   xyzzy
-    ${output}=  Run             ${VOS} examine xyzzy
-    Should Contain              ${output}  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
+    ${output}=    Run    ${VOS} examine xyzzy
+    Should Contain    ${output}    xyzzy
+    [Teardown]    Remove Volume    xyzzy
 
 Avoid creating a rogue volume during create
-    [Tags]         rogue-avoidance
-    [Teardown]     Cleanup Rogue    ${vid}
+    [Tags]    rogue-avoidance
     Set test variable    ${vid}    0
-    ${vid}=        Create volume    xyzzy    ${SERVER}    a    orphan=True
+    ${vid}=    Create volume    xyzzy    ${SERVER}    a    orphan=True
     Command Should Fail    ${VOS} create -server ${SERVER} -part b -name xyzzy -id ${vid}
+    [Teardown]    Cleanup Rogue    ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]     ${vid}
-    Remove volume   ${vid}    server=${SERVER}
-    Remove volume   ${vid}    server=${SERVER}    zap=True
+    [Arguments]    ${vid}
+    Remove volume    ${vid}    server=${SERVER}
+    Remove volume    ${vid}    server=${SERVER}    zap=True

--- a/tests/admin/volume/dump.robot
+++ b/tests/admin/volume/dump.robot
@@ -1,52 +1,55 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library            OperatingSystem
-Library            String
-Library            OpenAFSLibrary
-Suite Setup        Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown     Logout
-Test Teardown      Cleanup Test Volumes
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
+Test Teardown       Cleanup Test Volumes
 
 *** Variables ***
-${VOLUME}      test.dump
-${SERVER}      ${AFS_FILESERVER_A}
-${SERVER2}     ${AFS_FILESERVER_B}
-${PART}        a
-${DUMP}        /tmp/test.dump
-${DIR}         /afs/.${AFS_CELL}/test/${VOLUME}
+${VOLUME}       test.dump
+${SERVER}       ${AFS_FILESERVER_A}
+${SERVER2}      ${AFS_FILESERVER_B}
+${PART}         a
+${DUMP}         /tmp/test.dump
+${DIR}          /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***
 Dump an Empty Volume
-    Create Volume  ${VOLUME}  ${SERVER}  ${PART}  path=${DIR}
-    Command Should Succeed  ${VOS} dump -id ${VOLUME} -file ${DUMP}
+    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
+    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Dump a Volume
-    Create Volume  ${VOLUME}  ${SERVER}  ${PART}  path=${DIR}
-    Create Files   ${DIR}   size=512  count=64  depth=2  width=1  fill=random
-    Command Should Succeed  ${VOS} dump -id ${VOLUME} -file ${DUMP}
+    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
+    Create Files    ${DIR}    size=512    count=64    depth=2    width=1    fill=random
+    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Dump and Restore Data Integrity
     [Tags]    requires-multi-fs    requires-gdiff
-    Create Volume  ${VOLUME}  ${SERVER}  ${PART}  path=${DIR}
-    Create Files   ${DIR}   size=512  count=64  depth=2  width=1  fill=random
+    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
+    Create Files    ${DIR}    size=512    count=64    depth=2    width=1    fill=random
     Dump Volume
     Restore Volume
     Compare Files
 
 *** Keywords ***
 Cleanup Test Volumes
-    Remove Volume  ${VOLUME}    path=${DIR}
-    Remove Volume  ${VOLUME}.r  path=${DIR}.r
+    Remove Volume    ${VOLUME}    path=${DIR}
+    Remove Volume    ${VOLUME}.r    path=${DIR}.r
     Remove File    ${DUMP}
 
 Dump Volume
-    Command Should Succeed  ${VOS} dump -id ${VOLUME} -file ${DUMP}
+    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Restore Volume
-    Command Should Succeed  ${VOS} restore -server ${SERVER2} -part ${PART} -name ${VOLUME}.r -file ${DUMP} -overwrite full
-    Command Should Succeed  ${FS} mkmount -dir ${DIR}.r -vol ${VOLUME}.r
+    Command Should Succeed
+    ...    ${VOS} restore -server ${SERVER2} -part ${PART} -name ${VOLUME}.r -file ${DUMP} -overwrite full
+    Command Should Succeed    ${FS} mkmount -dir ${DIR}.r -vol ${VOLUME}.r
 
 Compare Files
-    Command Should Succeed  ${GDIFF} --recursive ${DIR} ${DIR}.r
+    Command Should Succeed    ${GDIFF} --recursive ${DIR} ${DIR}.r

--- a/tests/admin/volume/dump.robot
+++ b/tests/admin/volume/dump.robot
@@ -21,35 +21,35 @@ ${DIR}          /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***
 Dump an Empty Volume
-    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
-    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
+|  | Create Volume          | ${VOLUME}                               | ${SERVER} | ${PART} | path=${DIR}
+|  | Command Should Succeed | ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Dump a Volume
-    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
-    Create Files    ${DIR}    size=512    count=64    depth=2    width=1    fill=random
-    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
+|  | Create Volume          | ${VOLUME}                               | ${SERVER} | ${PART}  | path=${DIR}
+|  | Create Files           | ${DIR}                                  | size=512  | count=64 | depth=2     | width=1 | fill=random
+|  | Command Should Succeed | ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Dump and Restore Data Integrity
-    [Tags]    requires-multi-fs    requires-gdiff
-    Create Volume    ${VOLUME}    ${SERVER}    ${PART}    path=${DIR}
-    Create Files    ${DIR}    size=512    count=64    depth=2    width=1    fill=random
-    Dump Volume
-    Restore Volume
-    Compare Files
+|  | [Tags]         | requires-multi-fs | requires-gdiff
+|  | Create Volume  | ${VOLUME}         | ${SERVER}      | ${PART}  | path=${DIR}
+|  | Create Files   | ${DIR}            | size=512       | count=64 | depth=2     | width=1 | fill=random
+|  | Dump Volume
+|  | Restore Volume
+|  | Compare Files
 
 *** Keywords ***
 Cleanup Test Volumes
-    Remove Volume    ${VOLUME}    path=${DIR}
-    Remove Volume    ${VOLUME}.r    path=${DIR}.r
-    Remove File    ${DUMP}
+|  | Remove Volume | ${VOLUME}   | path=${DIR}
+|  | Remove Volume | ${VOLUME}.r | path=${DIR}.r
+|  | Remove File   | ${DUMP}
 
 Dump Volume
-    Command Should Succeed    ${VOS} dump -id ${VOLUME} -file ${DUMP}
+|  | Command Should Succeed | ${VOS} dump -id ${VOLUME} -file ${DUMP}
 
 Restore Volume
-    Command Should Succeed
-    ...    ${VOS} restore -server ${SERVER2} -part ${PART} -name ${VOLUME}.r -file ${DUMP} -overwrite full
-    Command Should Succeed    ${FS} mkmount -dir ${DIR}.r -vol ${VOLUME}.r
+|  | Command Should Succeed
+|  | ...                    | ${VOS} restore -server ${SERVER2} -part ${PART} -name ${VOLUME}.r -file ${DUMP} -overwrite full
+|  | Command Should Succeed | ${FS} mkmount -dir ${DIR}.r -vol ${VOLUME}.r
 
 Compare Files
-    Command Should Succeed    ${GDIFF} --recursive ${DIR} ${DIR}.r
+|  | Command Should Succeed | ${GDIFF} --recursive ${DIR} ${DIR}.r

--- a/tests/admin/volume/move.robot
+++ b/tests/admin/volume/move.robot
@@ -18,27 +18,27 @@ ${PART2}        b
 
 *** Test Cases ***
 Move a Volume
-    [Setup]    Create Volume    xyzzy    ${SERVER1}    ${PART1}
-    Command Should Succeed    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER1} ${PART2}
-    Volume Should Exist    xyzzy
-    Volume Location Matches    xyzzy    server=${SERVER1}    part=${PART2}
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]                 | Create Volume                                             | xyzzy             | ${SERVER1}    | ${PART1}
+|  | Command Should Succeed  | ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER1} ${PART2}
+|  | Volume Should Exist     | xyzzy
+|  | Volume Location Matches | xyzzy                                                     | server=${SERVER1} | part=${PART2}
+|  | [Teardown]              | Remove Volume                                             | xyzzy
 
 Move a volume between servers
-    [Tags]    requires-multi-fs
-    [Setup]    Create Volume    xyzzy    ${SERVER1}    ${PART1}
-    Command Should Succeed    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
-    [Teardown]    Remove Volume    xyzzy
+|  | [Tags]                 | requires-multi-fs
+|  | [Setup]                | Create Volume                                             | xyzzy | ${SERVER1} | ${PART1}
+|  | Command Should Succeed | ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+|  | [Teardown]             | Remove Volume                                             | xyzzy
 
 Avoid creating a rogue volume during move
-    [Tags]    requires-multi-fs    bug
-    ${vid}=    Create volume    xyzzy    ${SERVER2}    ${PART2}    orphan=True
-    Command Should Succeed    ${VOS} create -server ${SERVER1} -part ${PART1} -name xyzzy -id ${vid}
-    Command Should Fail    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
-    [Teardown]    Cleanup Rogue    ${vid}    ${AFS_FILESERVER_B}
+|  | [Tags]                 | requires-multi-fs                                                      | bug
+|  | ${vid}=                | Create volume                                                          | xyzzy  | ${SERVER2}          | ${PART2} | orphan=True
+|  | Command Should Succeed | ${VOS} create -server ${SERVER1} -part ${PART1} -name xyzzy -id ${vid}
+|  | Command Should Fail    | ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+|  | [Teardown]             | Cleanup Rogue                                                          | ${vid} | ${AFS_FILESERVER_B}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]    ${vid}    ${server}
-    Remove volume    ${vid}
-    Remove volume    ${vid}    server=${server}    zap=True
+|  | [Arguments]   | ${vid} | ${server}
+|  | Remove volume | ${vid}
+|  | Remove volume | ${vid} | server=${server} | zap=True

--- a/tests/admin/volume/move.robot
+++ b/tests/admin/volume/move.robot
@@ -1,42 +1,44 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${SERVER1}       ${AFS_FILESERVER_A}
-${SERVER2}       ${AFS_FILESERVER_B}
-${PART1}         a
-${PART2}         b
+${SERVER1}      ${AFS_FILESERVER_A}
+${SERVER2}      ${AFS_FILESERVER_B}
+${PART1}        a
+${PART2}        b
 
 *** Test Cases ***
 Move a Volume
-    [Setup]     Create Volume  xyzzy  ${SERVER1}  ${PART1}
-    [Teardown]  Remove Volume  xyzzy
-    Command Should Succeed   ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER1} ${PART2}
-    Volume Should Exist      xyzzy
-    Volume Location Matches  xyzzy  server=${SERVER1}  part=${PART2}
+    [Setup]    Create Volume    xyzzy    ${SERVER1}    ${PART1}
+    Command Should Succeed    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER1} ${PART2}
+    Volume Should Exist    xyzzy
+    Volume Location Matches    xyzzy    server=${SERVER1}    part=${PART2}
+    [Teardown]    Remove Volume    xyzzy
 
 Move a volume between servers
-    [Tags]      requires-multi-fs
-    [Setup]     Create Volume  xyzzy  ${SERVER1}  ${PART1}
-    [Teardown]  Remove Volume  xyzzy
-    Command Should Succeed   ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+    [Tags]    requires-multi-fs
+    [Setup]    Create Volume    xyzzy    ${SERVER1}    ${PART1}
+    Command Should Succeed    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+    [Teardown]    Remove Volume    xyzzy
 
 Avoid creating a rogue volume during move
-    [Tags]      requires-multi-fs  bug
-    [Teardown]  Cleanup Rogue    ${vid}   ${AFS_FILESERVER_B}
-    ${vid}=            Create volume    xyzzy    ${SERVER2}    ${PART2}    orphan=True
+    [Tags]    requires-multi-fs    bug
+    ${vid}=    Create volume    xyzzy    ${SERVER2}    ${PART2}    orphan=True
     Command Should Succeed    ${VOS} create -server ${SERVER1} -part ${PART1} -name xyzzy -id ${vid}
-    Command Should Fail       ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+    Command Should Fail    ${VOS} move xyzzy ${SERVER1} ${PART1} ${SERVER2} ${PART1}
+    [Teardown]    Cleanup Rogue    ${vid}    ${AFS_FILESERVER_B}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]     ${vid}    ${server}
-    Remove volume   ${vid}
-    Remove volume   ${vid}    server=${server}    zap=True
+    [Arguments]    ${vid}    ${server}
+    Remove volume    ${vid}
+    Remove volume    ${vid}    server=${server}    zap=True

--- a/tests/admin/volume/release.robot
+++ b/tests/admin/volume/release.robot
@@ -1,40 +1,41 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${SERVER}        ${AFS_FILESERVER_A}
-${PART}          a
-${OTHERPART}     b
-
+${SERVER}       ${AFS_FILESERVER_A}
+${PART}         a
+${OTHERPART}    b
 
 *** Test Cases ***
 Release a Volume
-    [Setup]     Create Volume  xyzzy  ${SERVER}  ${PART}
-    [Teardown]  Remove Volume  xyzzy
+    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
     Command Should Succeed    ${VOS} addsite ${SERVER} ${PART} xyzzy
     Command Should Succeed    ${VOS} release xyzzy
-    Volume Should Exist       xyzzy.readonly
-    Volume Location Matches   xyzzy  server=${SERVER}  part=${PART}  vtype=ro
+    Volume Should Exist    xyzzy.readonly
+    Volume Location Matches    xyzzy    server=${SERVER}    part=${PART}    vtype=ro
+    [Teardown]    Remove Volume    xyzzy
 
 Avoid creating a rogue volume during release
-    [Tags]         rogue-avoidance
-    [Teardown]     Run Keywords    Remove volume    xyzzz
-    ...            AND             Cleanup Rogue    ${vid}
+    [Tags]    rogue-avoidance
     Set test variable    ${vid}    0
-    ${vid}=        Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
+    ${vid}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
     Command Should Succeed    ${VOS} create ${SERVER} a xyzzz -roid ${vid}
     Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzz
-    Command Should Fail       ${VOS} release xyzzz
+    Command Should Fail    ${VOS} release xyzzz
+    [Teardown]    Run Keywords    Remove volume    xyzzz
+    ...    AND    Cleanup Rogue    ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]     ${vid}
-    Remove volume   ${vid}    server=${SERVER}
-    Remove volume   ${vid}    server=${SERVER}    zap=True
+    [Arguments]    ${vid}
+    Remove volume    ${vid}    server=${SERVER}
+    Remove volume    ${vid}    server=${SERVER}    zap=True

--- a/tests/admin/volume/release.robot
+++ b/tests/admin/volume/release.robot
@@ -17,25 +17,25 @@ ${OTHERPART}    b
 
 *** Test Cases ***
 Release a Volume
-    [Setup]    Create Volume    xyzzy    ${SERVER}    ${PART}
-    Command Should Succeed    ${VOS} addsite ${SERVER} ${PART} xyzzy
-    Command Should Succeed    ${VOS} release xyzzy
-    Volume Should Exist    xyzzy.readonly
-    Volume Location Matches    xyzzy    server=${SERVER}    part=${PART}    vtype=ro
-    [Teardown]    Remove Volume    xyzzy
+|  | [Setup]                 | Create Volume                          | xyzzy            | ${SERVER}    | ${PART}
+|  | Command Should Succeed  | ${VOS} addsite ${SERVER} ${PART} xyzzy
+|  | Command Should Succeed  | ${VOS} release xyzzy
+|  | Volume Should Exist     | xyzzy.readonly
+|  | Volume Location Matches | xyzzy                                  | server=${SERVER} | part=${PART} | vtype=ro
+|  | [Teardown]              | Remove Volume                          | xyzzy
 
 Avoid creating a rogue volume during release
-    [Tags]    rogue-avoidance
-    Set test variable    ${vid}    0
-    ${vid}=    Create volume    xyzzy    ${SERVER}    ${OTHERPART}    orphan=True
-    Command Should Succeed    ${VOS} create ${SERVER} a xyzzz -roid ${vid}
-    Command Should Succeed    ${VOS} addsite ${SERVER} a xyzzz
-    Command Should Fail    ${VOS} release xyzzz
-    [Teardown]    Run Keywords    Remove volume    xyzzz
-    ...    AND    Cleanup Rogue    ${vid}
+|  | [Tags]                 | rogue-avoidance
+|  | Set test variable      | ${vid}                                       | 0
+|  | ${vid}=                | Create volume                                | xyzzy         | ${SERVER} | ${OTHERPART} | orphan=True
+|  | Command Should Succeed | ${VOS} create ${SERVER} a xyzzz -roid ${vid}
+|  | Command Should Succeed | ${VOS} addsite ${SERVER} a xyzzz
+|  | Command Should Fail    | ${VOS} release xyzzz
+|  | [Teardown]             | Run Keywords                                 | Remove volume | xyzzz
+|  | ...                    | AND                                          | Cleanup Rogue | ${vid}
 
 *** Keywords ***
 Cleanup Rogue
-    [Arguments]    ${vid}
-    Remove volume    ${vid}    server=${SERVER}
-    Remove volume    ${vid}    server=${SERVER}    zap=True
+|  | [Arguments]   | ${vid}
+|  | Remove volume | ${vid} | server=${SERVER}
+|  | Remove volume | ${vid} | server=${SERVER} | zap=True

--- a/tests/admin/volume/restore.robot
+++ b/tests/admin/volume/restore.robot
@@ -24,40 +24,40 @@ ${DUMP}         /tmp/test.dump
 
 *** Test Cases ***
 Restore a volume
-    Volume should not exist    ${VOLUME}
-    Create dump    ${DUMP}    size=small
-    Command should succeed    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
-    Volume should exist    ${VOLUME}
-    Volume location matches    ${VOLUME}    ${SERVER}    ${PART}    vtype=rw
+|  | Volume should not exist | ${VOLUME}
+|  | Create dump             | ${DUMP}                                                                  | size=small
+|  | Command should succeed  | ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+|  | Volume should exist     | ${VOLUME}
+|  | Volume location matches | ${VOLUME}                                                                | ${SERVER}  | ${PART} | vtype=rw
 
 Restore an empty volume
-    Volume should not exist    ${VOLUME}
-    Create dump    ${DUMP}    size=empty
-    Command should succeed    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
-    Volume should exist    ${VOLUME}
-    Volume location matches    ${VOLUME}    ${SERVER}    ${PART}    vtype=rw
+|  | Volume should not exist | ${VOLUME}
+|  | Create dump             | ${DUMP}                                                                  | size=empty
+|  | Command should succeed  | ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+|  | Volume should exist     | ${VOLUME}
+|  | Volume location matches | ${VOLUME}                                                                | ${SERVER}  | ${PART} | vtype=rw
 
 Restore a Volume Containing a Bogus ACL
-    Volume should not exist    ${VOLUME}
-    Create dump    ${DUMP}    size=small    contains=bogus-acl
-    Command Should Fail    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+|  | Volume should not exist | ${VOLUME}
+|  | Create dump             | ${DUMP}                                                                  | size=small | contains=bogus-acl
+|  | Command Should Fail     | ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
 
 Avoid creating a rogue volume during restore
-    [Tags]    rogue-avoidance
-    Set test variable    ${vid}    0
-    ${vid}=    Create volume    ${VOLUME}    ${SERVER}    a    orphan=True
-    Create dump    ${DUMP}    size=small
-    Command should fail
-    ...    ${VOS} restore -server ${SERVER} -part b -name ${VOLUME} -id ${vid} -file ${DUMP} -overwrite full
-    [Teardown]    Cleanup Rogue    ${vid}
+|  | [Tags]              | rogue-avoidance
+|  | Set test variable   | ${vid}                                                                                            | 0
+|  | ${vid}=             | Create volume                                                                                     | ${VOLUME}  | ${SERVER} | a | orphan=True
+|  | Create dump         | ${DUMP}                                                                                           | size=small
+|  | Command should fail
+|  | ...                 | ${VOS} restore -server ${SERVER} -part b -name ${VOLUME} -id ${vid} -file ${DUMP} -overwrite full
+|  | [Teardown]          | Cleanup Rogue                                                                                     | ${vid}
 
 *** Keywords ***
 Cleanup
-    Remove volume    ${VOLUME}
-    Remove file    ${DUMP}
+|  | Remove volume | ${VOLUME}
+|  | Remove file   | ${DUMP}
 
 Cleanup Rogue
-    [Arguments]    ${vid}
-    Remove volume    ${vid}    server=${SERVER}
-    Remove volume    ${vid}    server=${SERVER}    zap=True
-    Remove file    ${DUMP}
+|  | [Arguments]   | ${vid}
+|  | Remove volume | ${vid}  | server=${SERVER}
+|  | Remove volume | ${vid}  | server=${SERVER} | zap=True
+|  | Remove file   | ${DUMP}

--- a/tests/admin/volume/restore.robot
+++ b/tests/admin/volume/restore.robot
@@ -1,3 +1,4 @@
+*** Comments ***
 # Copyright (c) 2015-2017 Sine Nomine Associates
 # See LICENSE
 
@@ -6,55 +7,57 @@ Documentation       Tests to verify volume restore operations with the
 ...                 various of the restore options and to test the volume
 ...                 server robustness while attempting to restore invalid
 ...                 volume dump streams.
+
 Library             OperatingSystem
 Library             String
 Library             OpenAFSLibrary
-Suite Setup         Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
 Suite Teardown      Logout
 Test Teardown       Cleanup
 
 *** Variables ***
-${VOLUME}           test.restore
-${PART}             a
-${SERVER}           ${AFS_FILESERVER_A}
-${DUMP}             /tmp/test.dump
+${VOLUME}       test.restore
+${PART}         a
+${SERVER}       ${AFS_FILESERVER_A}
+${DUMP}         /tmp/test.dump
 
 *** Test Cases ***
 Restore a volume
-    Volume should not exist  ${VOLUME}
-    Create dump              ${DUMP}    size=small
-    Command should succeed   ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
-    Volume should exist      ${VOLUME}
-    Volume location matches  ${VOLUME}  ${SERVER}  ${PART}  vtype=rw
+    Volume should not exist    ${VOLUME}
+    Create dump    ${DUMP}    size=small
+    Command should succeed    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+    Volume should exist    ${VOLUME}
+    Volume location matches    ${VOLUME}    ${SERVER}    ${PART}    vtype=rw
 
 Restore an empty volume
-    Volume should not exist  ${VOLUME}
-    Create dump              ${DUMP}    size=empty
-    Command should succeed   ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
-    Volume should exist      ${VOLUME}
-    Volume location matches  ${VOLUME}  ${SERVER}  ${PART}  vtype=rw
+    Volume should not exist    ${VOLUME}
+    Create dump    ${DUMP}    size=empty
+    Command should succeed    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+    Volume should exist    ${VOLUME}
+    Volume location matches    ${VOLUME}    ${SERVER}    ${PART}    vtype=rw
 
 Restore a Volume Containing a Bogus ACL
-    Volume should not exist  ${VOLUME}
-    Create dump              ${DUMP}    size=small      contains=bogus-acl
-    Command Should Fail      ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
+    Volume should not exist    ${VOLUME}
+    Create dump    ${DUMP}    size=small    contains=bogus-acl
+    Command Should Fail    ${VOS} restore ${SERVER} ${PART} ${VOLUME} -file ${DUMP} -overwrite full
 
 Avoid creating a rogue volume during restore
-    [Tags]         rogue-avoidance
-    [Teardown]     Cleanup Rogue    ${vid}
+    [Tags]    rogue-avoidance
     Set test variable    ${vid}    0
-    ${vid}=        Create volume    ${VOLUME}    ${SERVER}    a    orphan=True
+    ${vid}=    Create volume    ${VOLUME}    ${SERVER}    a    orphan=True
     Create dump    ${DUMP}    size=small
     Command should fail
     ...    ${VOS} restore -server ${SERVER} -part b -name ${VOLUME} -id ${vid} -file ${DUMP} -overwrite full
+    [Teardown]    Cleanup Rogue    ${vid}
 
 *** Keywords ***
 Cleanup
-    Remove volume   ${VOLUME}
-    Remove file     ${DUMP}
+    Remove volume    ${VOLUME}
+    Remove file    ${DUMP}
 
 Cleanup Rogue
-    [Arguments]     ${vid}
-    Remove volume   ${vid}    server=${SERVER}
-    Remove volume   ${vid}    server=${SERVER}    zap=True
-    Remove file     ${DUMP}
+    [Arguments]    ${vid}
+    Remove volume    ${vid}    server=${SERVER}
+    Remove volume    ${vid}    server=${SERVER}    zap=True
+    Remove file    ${DUMP}

--- a/tests/workload/basic.robot
+++ b/tests/workload/basic.robot
@@ -32,185 +32,185 @@ ${TEXT}         hello-world
 
 *** Test Cases ***
 Create a File
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${FILE}
-    Command Should Succeed    touch ${FILE}
-    Should Be File    ${FILE}
-    Should Not Be Symlink    ${FILE}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]                | Run Keyword
+|  | ...                    | Should Not Exist | ${FILE}
+|  | Command Should Succeed | touch ${FILE}
+|  | Should Be File         | ${FILE}
+|  | Should Not Be Symlink  | ${FILE}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File      | ${FILE} | AND
+|  | ...                    | Should Not Exist | ${FILE}
 
 Create a Directory
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${DIR}
-    Create Directory    ${DIR}
-    Should Exist    ${DIR}
-    Should Be Dir    ${DIR}
-    Should Be Dir    ${DIR}/.
-    Should Be Dir    ${DIR}/..
-    [Teardown]    Run Keywords
-    ...    Remove Directory    ${DIR}    AND
-    ...    Should Not Exist    ${DIR}
+|  | [Setup]          | Run Keyword
+|  | ...              | Should Not Exist | ${DIR}
+|  | Create Directory | ${DIR}
+|  | Should Exist     | ${DIR}
+|  | Should Be Dir    | ${DIR}
+|  | Should Be Dir    | ${DIR}/.
+|  | Should Be Dir    | ${DIR}/..
+|  | [Teardown]       | Run Keywords
+|  | ...              | Remove Directory | ${DIR} | AND
+|  | ...              | Should Not Exist | ${DIR}
 
 Create a Symlink
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${SYMLINK}    AND
-    ...    Create Directory    ${DIR}
-    Symlink    ${DIR}    ${SYMLINK}
-    Should Be Symlink    ${SYMLINK}
-    [Teardown]    Run Keywords
-    ...    Unlink    ${SYMLINK}    AND
-    ...    Remove Directory    ${DIR}    AND
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${SYMLINK}
+|  | [Setup]           | Run Keywords
+|  | ...               | Should Not Exist | ${DIR}     | AND
+|  | ...               | Should Not Exist | ${SYMLINK} | AND
+|  | ...               | Create Directory | ${DIR}
+|  | Symlink           | ${DIR}           | ${SYMLINK}
+|  | Should Be Symlink | ${SYMLINK}
+|  | [Teardown]        | Run Keywords
+|  | ...               | Unlink           | ${SYMLINK} | AND
+|  | ...               | Remove Directory | ${DIR}     | AND
+|  | ...               | Should Not Exist | ${DIR}     | AND
+|  | ...               | Should Not Exist | ${SYMLINK}
 
 Create a Hard Link within a Directory
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE}    AND
-    ...    Should Not Exist    ${LINK}    AND
-    ...    Create File    ${FILE}
-    Link Count Should Be    ${FILE}    1
-    Link    ${FILE}    ${LINK}
-    Inode Should Be Equal    ${LINK}    ${FILE}
-    Link Count Should Be    ${FILE}    2
-    Link Count Should Be    ${LINK}    2
-    Unlink    ${LINK}
-    Should Not Exist    ${LINK}
-    Link Count Should Be    ${FILE}    1
-    [Teardown]    Run Keyword
-    ...    Remove File    ${FILE}
+|  | [Setup]               | Run Keywords
+|  | ...                   | Should Not Exist | ${FILE} | AND
+|  | ...                   | Should Not Exist | ${LINK} | AND
+|  | ...                   | Create File      | ${FILE}
+|  | Link Count Should Be  | ${FILE}          | 1
+|  | Link                  | ${FILE}          | ${LINK}
+|  | Inode Should Be Equal | ${LINK}          | ${FILE}
+|  | Link Count Should Be  | ${FILE}          | 2
+|  | Link Count Should Be  | ${LINK}          | 2
+|  | Unlink                | ${LINK}
+|  | Should Not Exist      | ${LINK}
+|  | Link Count Should Be  | ${FILE}          | 1
+|  | [Teardown]            | Run Keyword
+|  | ...                   | Remove File      | ${FILE}
 
 Create a Hard Link within a Volume
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${DIR2}    AND
-    ...    Should Not Exist    ${LINK2}    AND
-    ...    Should Not Exist    ${FILE3}    AND
-    ...    Create Directory    ${DIR}    AND
-    ...    Create Directory    ${DIR2}    AND
-    ...    Create File    ${FILE3}
-    Link    ${FILE3}    ${LINK2}    code_should_be=EXDEV
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE3}    AND
-    ...    Remove File    ${LINK2}    AND
-    ...    Remove Directory    ${DIR}    AND
-    ...    Remove Directory    ${DIR2}    AND
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${DIR2}    AND
-    ...    Should Not Exist    ${LINK2}    AND
-    ...    Should Not Exist    ${FILE3}
+|  | [Setup]    | Run Keywords
+|  | ...        | Should Not Exist | ${DIR}   | AND
+|  | ...        | Should Not Exist | ${DIR2}  | AND
+|  | ...        | Should Not Exist | ${LINK2} | AND
+|  | ...        | Should Not Exist | ${FILE3} | AND
+|  | ...        | Create Directory | ${DIR}   | AND
+|  | ...        | Create Directory | ${DIR2}  | AND
+|  | ...        | Create File      | ${FILE3}
+|  | Link       | ${FILE3}         | ${LINK2} | code_should_be=EXDEV
+|  | [Teardown] | Run Keywords
+|  | ...        | Remove File      | ${FILE3} | AND
+|  | ...        | Remove File      | ${LINK2} | AND
+|  | ...        | Remove Directory | ${DIR}   | AND
+|  | ...        | Remove Directory | ${DIR2}  | AND
+|  | ...        | Should Not Exist | ${DIR}   | AND
+|  | ...        | Should Not Exist | ${DIR2}  | AND
+|  | ...        | Should Not Exist | ${LINK2} | AND
+|  | ...        | Should Not Exist | ${FILE3}
 
 Create a Hard Link to a Directory
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${LINK}    AND
-    ...    Create Directory    ${DIR}
-    Should Exist    ${DIR}
-    Should Be Dir    ${DIR}
-    Run Keyword and Expect Error    *
-    ...    Link    ${DIR}    ${LINK}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${LINK}    AND
-    ...    Remove Directory    ${DIR}    AND
-    ...    Should Not Exist    ${DIR}    AND
-    ...    Should Not Exist    ${LINK}
+|  | [Setup]                      | Run Keywords
+|  | ...                          | Should Not Exist | ${DIR}  | AND
+|  | ...                          | Should Not Exist | ${LINK} | AND
+|  | ...                          | Create Directory | ${DIR}
+|  | Should Exist                 | ${DIR}
+|  | Should Be Dir                | ${DIR}
+|  | Run Keyword and Expect Error | *
+|  | ...                          | Link             | ${DIR}  | ${LINK}
+|  | [Teardown]                   | Run Keywords
+|  | ...                          | Remove File      | ${LINK} | AND
+|  | ...                          | Remove Directory | ${DIR}  | AND
+|  | ...                          | Should Not Exist | ${DIR}  | AND
+|  | ...                          | Should Not Exist | ${LINK}
 
 Create a Cross-Volume Hard Link
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${NVOLUME}    AND
-    ...    Create Volume    xyzzy    server=${SERVER}    part=${PARTITION}    path=${NVOLUME}    acl=system:anyuser,read
-    Run Keyword and Expect Error    *
-    ...    Link    ${TESTPATH}    ${NVOLUME}
-    [Teardown]    Run Keywords
-    ...    Remove Volume    xyzzy    path=${NVOLUME}    AND
-    ...    Remove File    ${NVOLUME}    AND
-    ...    Should Not Exist    ${NVOLUME}
+|  | [Setup]                      | Run Keywords
+|  | ...                          | Should Not Exist | ${NVOLUME}  | AND
+|  | ...                          | Create Volume    | xyzzy       | server=${SERVER} | part=${PARTITION} | path=${NVOLUME} | acl=system:anyuser,read
+|  | Run Keyword and Expect Error | *
+|  | ...                          | Link             | ${TESTPATH} | ${NVOLUME}
+|  | [Teardown]                   | Run Keywords
+|  | ...                          | Remove Volume    | xyzzy       | path=${NVOLUME}  | AND
+|  | ...                          | Remove File      | ${NVOLUME}  | AND
+|  | ...                          | Should Not Exist | ${NVOLUME}
 
 Touch a file
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${FILE}
-    Command Should Succeed    touch ${FILE}
-    Should Exist    ${FILE}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]                | Run Keyword
+|  | ...                    | Should Not Exist | ${FILE}
+|  | Command Should Succeed | touch ${FILE}
+|  | Should Exist           | ${FILE}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File      | ${FILE} | AND
+|  | ...                    | Should Not Exist | ${FILE}
 
 Timestamp rollover after 2147483647 (January 19, 2038 03:14:07 UTC)
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${FILE}
-    Command Should Succeed    touch ${FILE}
-    Should Exist    ${FILE}
-    Set Modified Time    ${FILE}    2147483647
-    ${secs}=    Get Modified Time    ${FILE}    epoch
-    Should Be Equal    ${secs}    ${2147483647}
-    Set Modified Time    ${FILE}    2147483648
-    ${secs}=    Get Modified Time    ${FILE}    epoch
-    Should Not Be Equal    ${secs}    ${2147483648}
-    Should Be Equal    ${secs}    ${-2147483648}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]                | Run Keyword
+|  | ...                    | Should Not Exist  | ${FILE}
+|  | Command Should Succeed | touch ${FILE}
+|  | Should Exist           | ${FILE}
+|  | Set Modified Time      | ${FILE}           | 2147483647
+|  | ${secs}=               | Get Modified Time | ${FILE}        | epoch
+|  | Should Be Equal        | ${secs}           | ${2147483647}
+|  | Set Modified Time      | ${FILE}           | 2147483648
+|  | ${secs}=               | Get Modified Time | ${FILE}        | epoch
+|  | Should Not Be Equal    | ${secs}           | ${2147483648}
+|  | Should Be Equal        | ${secs}           | ${-2147483648}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File       | ${FILE}        | AND
+|  | ...                    | Should Not Exist  | ${FILE}
 
 Write to a File
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE}    AND
-    ...    Create File    ${FILE}    Hello world!\n
-    Should Exist    ${FILE}
-    ${TEXT}=    Get File    ${FILE}
-    Should Be Equal    ${TEXT}    Hello world!\n
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]         | Run Keywords
+|  | ...             | Should Not Exist | ${FILE}        | AND
+|  | ...             | Create File      | ${FILE}        | Hello world!\n
+|  | Should Exist    | ${FILE}
+|  | ${TEXT}=        | Get File         | ${FILE}
+|  | Should Be Equal | ${TEXT}          | Hello world!\n
+|  | [Teardown]      | Run Keywords
+|  | ...             | Remove File      | ${FILE}        | AND
+|  | ...             | Should Not Exist | ${FILE}
 
 Rewrite a file
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE}    AND
-    ...    Create File    ${FILE}    Hello world!\n
-    Should Exist    ${FILE}
-    ${TEXT}=    Get File    ${FILE}
-    Command Should Succeed    echo "Hey Cleveland\n" > ${FILE}
-    ${text2}=    Get File    ${FILE}
-    Should Not Be Equal    ${TEXT}    ${text2}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]                | Run Keywords
+|  | ...                    | Should Not Exist                 | ${FILE}  | AND
+|  | ...                    | Create File                      | ${FILE}  | Hello world!\n
+|  | Should Exist           | ${FILE}
+|  | ${TEXT}=               | Get File                         | ${FILE}
+|  | Command Should Succeed | echo "Hey Cleveland\n" > ${FILE}
+|  | ${text2}=              | Get File                         | ${FILE}
+|  | Should Not Be Equal    | ${TEXT}                          | ${text2}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File                      | ${FILE}  | AND
+|  | ...                    | Should Not Exist                 | ${FILE}
 
 Rename a File
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE1}    AND
-    ...    Should Not Exist    ${FILE2}    AND
-    ...    Create File    ${FILE1}
-    ${before}=    Get Inode    ${FILE1}
-    Command Should Succeed    mv ${FILE1} ${FILE2}
-    ${after}=    Get Inode    ${FILE2}
-    Should Be Equal    ${before}    ${after}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE2}    AND
-    ...    Should Not Exist    ${FILE2}
+|  | [Setup]                | Run Keywords
+|  | ...                    | Should Not Exist     | ${FILE1} | AND
+|  | ...                    | Should Not Exist     | ${FILE2} | AND
+|  | ...                    | Create File          | ${FILE1}
+|  | ${before}=             | Get Inode            | ${FILE1}
+|  | Command Should Succeed | mv ${FILE1} ${FILE2}
+|  | ${after}=              | Get Inode            | ${FILE2}
+|  | Should Be Equal        | ${before}            | ${after}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File          | ${FILE2} | AND
+|  | ...                    | Should Not Exist     | ${FILE2}
 
 Write and Execute a Script in a Directory
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${SCRIPT}
-    ${code}=    Catenate
-    ...    \#!/bin/sh\n
-    ...    echo ${TEXT}\n
-    Create File    ${SCRIPT}    ${code}
-    Should Exist    ${SCRIPT}
-    Command Should Succeed    chmod +x ${SCRIPT}
-    File Should Be Executable    ${SCRIPT}
-    ${rc}    ${output}=    Run And Return Rc And Output    ${SCRIPT}
-    Should Be Equal As Integers    ${rc}    0
-    Should Match    ${output}    ${TEXT}
-    [Teardown]    Run Keyword
-    ...    Remove File    ${SCRIPT}
+|  | [Setup]                     | Run Keyword
+|  | ...                         | Should Not Exist   | ${SCRIPT}
+|  | ${code}=                    | Catenate
+|  | ...                         | \#!/bin/sh\n
+|  | ...                         | echo ${TEXT}\n
+|  | Create File                 | ${SCRIPT}          | ${code}
+|  | Should Exist                | ${SCRIPT}
+|  | Command Should Succeed      | chmod +x ${SCRIPT}
+|  | File Should Be Executable   | ${SCRIPT}
+|  | ${rc}                       | ${output}=         | Run And Return Rc And Output | ${SCRIPT}
+|  | Should Be Equal As Integers | ${rc}              | 0
+|  | Should Match                | ${output}          | ${TEXT}
+|  | [Teardown]                  | Run Keyword
+|  | ...                         | Remove File        | ${SCRIPT}
 
 *** Keywords ***
 Setup
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+|  | Login         | ${AFS_ADMIN} | keytab=${AFS_ADMIN_KEYTAB}
+|  | Create Volume | ${VOLUME}    | server=${SERVER}           | part=${PARTITION} | path=${TESTPATH} | acl=system:anyuser,read
 
 Teardown
-    Remove Volume    ${VOLUME}    path=${TESTPATH}
-    Logout
+|  | Remove Volume | ${VOLUME} | path=${TESTPATH}
+|  | Logout

--- a/tests/workload/basic.robot
+++ b/tests/workload/basic.robot
@@ -1,213 +1,216 @@
+*** Comments ***
 # Copyright (c) 2014-2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Basic Functional Tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup
-Suite Teardown    Teardown
+Documentation       Basic Functional Tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup
+Suite Teardown      Teardown
 
 *** Variables ***
-${VOLUME}     test.basic
-${PARTITION}  a
-${SERVER}     ${AFS_FILESERVER_A}
-${TESTPATH}   /afs/.${AFS_CELL}/test/${VOLUME}
-${DIR2}       ${TESTPATH}/dir2
-${DIR}        ${TESTPATH}/dir
-${FILE1}      ${TESTPATH}/a
-${FILE2}      ${TESTPATH}/b
-${FILE3}      ${TESTPATH}/dir/file
-${FILE}       ${TESTPATH}/file
-${LINK2}      ${TESTPATH}/dir2/link
-${LINK}       ${TESTPATH}/link
-${NVOLUME}    ${TESTPATH}/xyzzy
-${SCRIPT}     ${TESTPATH}/script.sh
-${SYMLINK}    ${TESTPATH}/symlink
-${TEXT}       hello-world
-
-*** Keywords ***
-Setup
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume  ${VOLUME}  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}  acl=system:anyuser,read
-
-Teardown
-    Remove Volume  ${VOLUME}  path=${TESTPATH}
-    Logout
+${VOLUME}       test.basic
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
+${DIR2}         ${TESTPATH}/dir2
+${DIR}          ${TESTPATH}/dir
+${FILE1}        ${TESTPATH}/a
+${FILE2}        ${TESTPATH}/b
+${FILE3}        ${TESTPATH}/dir/file
+${FILE}         ${TESTPATH}/file
+${LINK2}        ${TESTPATH}/dir2/link
+${LINK}         ${TESTPATH}/link
+${NVOLUME}      ${TESTPATH}/xyzzy
+${SCRIPT}       ${TESTPATH}/script.sh
+${SYMLINK}      ${TESTPATH}/symlink
+${TEXT}         hello-world
 
 *** Test Cases ***
 Create a File
-    [Setup]  Run Keyword
-    ...      Should Not Exist        ${FILE}
-    Command Should Succeed  touch ${FILE}
-    Should Be File          ${FILE}
-    Should Not Be Symlink   ${FILE}
-    [Teardown]  Run Keywords
-    ...         Remove File             ${FILE}  AND
-    ...         Should Not Exist        ${FILE}
+    [Setup]    Run Keyword
+    ...    Should Not Exist    ${FILE}
+    Command Should Succeed    touch ${FILE}
+    Should Be File    ${FILE}
+    Should Not Be Symlink    ${FILE}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Create a Directory
-    [Setup]   Run Keyword
-    ...       Should Not Exist  ${DIR}
-    Create Directory  ${DIR}
-    Should Exist      ${DIR}
-    Should Be Dir     ${DIR}
-    Should Be Dir     ${DIR}/.
-    Should Be Dir     ${DIR}/..
-    [Teardown]  Run Keywords
-    ...         Remove Directory  ${DIR}  AND
-    ...         Should Not Exist  ${DIR}
+    [Setup]    Run Keyword
+    ...    Should Not Exist    ${DIR}
+    Create Directory    ${DIR}
+    Should Exist    ${DIR}
+    Should Be Dir    ${DIR}
+    Should Be Dir    ${DIR}/.
+    Should Be Dir    ${DIR}/..
+    [Teardown]    Run Keywords
+    ...    Remove Directory    ${DIR}    AND
+    ...    Should Not Exist    ${DIR}
 
 Create a Symlink
-    [Setup]  Run Keywords
-    ...    Should Not Exist        ${DIR}  AND
-    ...    Should Not Exist        ${SYMLINK}  AND
-    ...    Create Directory        ${DIR}
-    Symlink                 ${DIR}    ${SYMLINK}
-    Should Be Symlink       ${SYMLINK}
-    [Teardown]  Run Keywords
-    ...    Unlink                  ${SYMLINK}  AND
-    ...    Remove Directory        ${DIR}  AND
-    ...    Should Not Exist        ${DIR}  AND
-    ...    Should Not Exist        ${SYMLINK}
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${SYMLINK}    AND
+    ...    Create Directory    ${DIR}
+    Symlink    ${DIR}    ${SYMLINK}
+    Should Be Symlink    ${SYMLINK}
+    [Teardown]    Run Keywords
+    ...    Unlink    ${SYMLINK}    AND
+    ...    Remove Directory    ${DIR}    AND
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${SYMLINK}
 
 Create a Hard Link within a Directory
-    [Setup]  Run Keywords
-    ...    Should Not Exist        ${FILE}    AND
-    ...    Should Not Exist        ${LINK}    AND
-    ...    Create File             ${FILE}
-    [Teardown]  Run Keyword
-    ...    Remove File             ${FILE}
-    Link Count Should Be    ${FILE}  1
-    Link                    ${FILE}  ${LINK}
-    Inode Should Be Equal   ${LINK}  ${FILE}
-    Link Count Should Be    ${FILE}  2
-    Link Count Should Be    ${LINK}  2
-    Unlink                  ${LINK}
-    Should Not Exist        ${LINK}
-    Link Count Should Be    ${FILE}  1
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE}    AND
+    ...    Should Not Exist    ${LINK}    AND
+    ...    Create File    ${FILE}
+    Link Count Should Be    ${FILE}    1
+    Link    ${FILE}    ${LINK}
+    Inode Should Be Equal    ${LINK}    ${FILE}
+    Link Count Should Be    ${FILE}    2
+    Link Count Should Be    ${LINK}    2
+    Unlink    ${LINK}
+    Should Not Exist    ${LINK}
+    Link Count Should Be    ${FILE}    1
+    [Teardown]    Run Keyword
+    ...    Remove File    ${FILE}
 
 Create a Hard Link within a Volume
-    [Setup]     Run Keywords
-    ...    Should Not Exist         ${DIR}      AND
-    ...    Should Not Exist         ${DIR2}     AND
-    ...    Should Not Exist         ${LINK2}    AND
-    ...    Should Not Exist         ${FILE3}    AND
-    ...    Create Directory         ${DIR}      AND
-    ...    Create Directory         ${DIR2}     AND
-    ...    Create File              ${FILE3}
-    [Teardown]  Run Keywords
-    ...    Remove File              ${FILE3}    AND
-    ...    Remove File              ${LINK2}    AND
-    ...    Remove Directory         ${DIR}      AND
-    ...    Remove Directory         ${DIR2}     AND
-    ...    Should Not Exist         ${DIR}      AND
-    ...    Should Not Exist         ${DIR2}     AND
-    ...    Should Not Exist         ${LINK2}    AND
-    ...    Should Not Exist         ${FILE3}
-    Link    ${FILE3}  ${LINK2}  code_should_be=EXDEV
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${DIR2}    AND
+    ...    Should Not Exist    ${LINK2}    AND
+    ...    Should Not Exist    ${FILE3}    AND
+    ...    Create Directory    ${DIR}    AND
+    ...    Create Directory    ${DIR2}    AND
+    ...    Create File    ${FILE3}
+    Link    ${FILE3}    ${LINK2}    code_should_be=EXDEV
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE3}    AND
+    ...    Remove File    ${LINK2}    AND
+    ...    Remove Directory    ${DIR}    AND
+    ...    Remove Directory    ${DIR2}    AND
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${DIR2}    AND
+    ...    Should Not Exist    ${LINK2}    AND
+    ...    Should Not Exist    ${FILE3}
 
 Create a Hard Link to a Directory
-    [Setup]  Run Keywords
-    ...    Should Not Exist        ${DIR}  AND
-    ...    Should Not Exist        ${LINK}  AND
-    ...    Create Directory        ${DIR}
-    Should Exist     ${DIR}
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${LINK}    AND
+    ...    Create Directory    ${DIR}
+    Should Exist    ${DIR}
     Should Be Dir    ${DIR}
-    Run Keyword and Expect Error   *
-    ...    Link      ${DIR}    ${LINK}
-    [Teardown]  Run Keywords
-    ...    Remove File             ${LINK}  AND
-    ...    Remove Directory        ${DIR}  AND
-    ...    Should Not Exist        ${DIR}  AND
-    ...    Should Not Exist        ${LINK}
+    Run Keyword and Expect Error    *
+    ...    Link    ${DIR}    ${LINK}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${LINK}    AND
+    ...    Remove Directory    ${DIR}    AND
+    ...    Should Not Exist    ${DIR}    AND
+    ...    Should Not Exist    ${LINK}
 
 Create a Cross-Volume Hard Link
-    [Setup]  Run Keywords
-    ...    Should Not Exist           ${NVOLUME}  AND
-    ...    Create Volume  xyzzy  server=${SERVER}  part=${PARTITION}  path=${NVOLUME}  acl=system:anyuser,read
-    Run Keyword and Expect Error   *
-    ...    Link  ${TESTPATH}  ${NVOLUME}
-    [Teardown]  Run Keywords
-    ...    Remove Volume  xyzzy  path=${NVOLUME}  AND
-    ...    Remove File                ${NVOLUME}  AND
-    ...    Should Not Exist           ${NVOLUME}
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${NVOLUME}    AND
+    ...    Create Volume    xyzzy    server=${SERVER}    part=${PARTITION}    path=${NVOLUME}    acl=system:anyuser,read
+    Run Keyword and Expect Error    *
+    ...    Link    ${TESTPATH}    ${NVOLUME}
+    [Teardown]    Run Keywords
+    ...    Remove Volume    xyzzy    path=${NVOLUME}    AND
+    ...    Remove File    ${NVOLUME}    AND
+    ...    Should Not Exist    ${NVOLUME}
 
 Touch a file
-    [Setup]  Run Keyword
-    ...    Should Not Exist        ${FILE}
-    Command Should Succeed  touch ${FILE}
-    Should Exist            ${FILE}
-    [Teardown]  Run Keywords
-    ...    Remove File             ${FILE}  AND
-    ...    Should Not Exist        ${FILE}
+    [Setup]    Run Keyword
+    ...    Should Not Exist    ${FILE}
+    Command Should Succeed    touch ${FILE}
+    Should Exist    ${FILE}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Timestamp rollover after 2147483647 (January 19, 2038 03:14:07 UTC)
-    [Setup]  Run Keyword
-    ...    Should Not Exist        ${FILE}
-    Command Should Succeed   touch ${FILE}
-    Should Exist                   ${FILE}
-    Set Modified Time              ${FILE}   2147483647
-    ${secs}=  Get Modified Time    ${FILE}   epoch
-    Should Be Equal                ${secs}   ${2147483647}
-    Set Modified Time              ${FILE}   2147483648
-    ${secs}=  Get Modified Time    ${FILE}   epoch
-    Should Not Be Equal            ${secs}   ${2147483648}
-    Should Be Equal                ${secs}  ${-2147483648}
-    [Teardown]  Run Keywords
-    ...    Remove File             ${FILE}  AND
-    ...    Should Not Exist        ${FILE}
+    [Setup]    Run Keyword
+    ...    Should Not Exist    ${FILE}
+    Command Should Succeed    touch ${FILE}
+    Should Exist    ${FILE}
+    Set Modified Time    ${FILE}    2147483647
+    ${secs}=    Get Modified Time    ${FILE}    epoch
+    Should Be Equal    ${secs}    ${2147483647}
+    Set Modified Time    ${FILE}    2147483648
+    ${secs}=    Get Modified Time    ${FILE}    epoch
+    Should Not Be Equal    ${secs}    ${2147483648}
+    Should Be Equal    ${secs}    ${-2147483648}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Write to a File
-    [Setup]  Run Keywords
-    ...    Should Not Exist    ${FILE}  AND
-    ...    Create File         ${FILE}  Hello world!\n
-    Should Exist        ${FILE}
-    ${TEXT}=  Get File  ${FILE}
-    Should Be Equal     ${TEXT}  Hello world!\n
-    [Teardown]  Run Keywords
-    ...    Remove File         ${FILE}  AND
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE}    AND
+    ...    Create File    ${FILE}    Hello world!\n
+    Should Exist    ${FILE}
+    ${TEXT}=    Get File    ${FILE}
+    Should Be Equal    ${TEXT}    Hello world!\n
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
     ...    Should Not Exist    ${FILE}
 
 Rewrite a file
-    [Setup]  Run Keywords
-    ...    Should Not Exist        ${FILE}  AND
-    ...    Create File             ${FILE}  Hello world!\n
-    Should Exist            ${FILE}
-    ${TEXT}=  Get File      ${FILE}
-    Command Should Succeed  echo "Hey Cleveland\n" > ${FILE}
-    ${text2}=  Get File     ${FILE}
-    Should Not Be Equal     ${TEXT}  ${text2}
-    [Teardown]  Run Keywords
-    ...    Remove File             ${FILE}  AND
-    ...    Should Not Exist        ${FILE}
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE}    AND
+    ...    Create File    ${FILE}    Hello world!\n
+    Should Exist    ${FILE}
+    ${TEXT}=    Get File    ${FILE}
+    Command Should Succeed    echo "Hey Cleveland\n" > ${FILE}
+    ${text2}=    Get File    ${FILE}
+    Should Not Be Equal    ${TEXT}    ${text2}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Rename a File
-    [Setup]  Run Keywords
-    ...    Should Not Exist  ${FILE1}  AND
-    ...    Should Not Exist  ${FILE2}  AND
-    ...    Create File  ${FILE1}
-    ${before}=  Get Inode  ${FILE1}
-    Command Should Succeed  mv ${FILE1} ${FILE2}
-    ${after}=   Get Inode  ${FILE2}
-    Should Be Equal  ${before}  ${after}
-    [Teardown]  Run Keywords
-    ...    Remove File  ${FILE2}  AND
-    ...    Should Not Exist  ${FILE2}
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE1}    AND
+    ...    Should Not Exist    ${FILE2}    AND
+    ...    Create File    ${FILE1}
+    ${before}=    Get Inode    ${FILE1}
+    Command Should Succeed    mv ${FILE1} ${FILE2}
+    ${after}=    Get Inode    ${FILE2}
+    Should Be Equal    ${before}    ${after}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE2}    AND
+    ...    Should Not Exist    ${FILE2}
 
 Write and Execute a Script in a Directory
-    [Setup]  Run Keyword
-    ...    Should Not Exist      ${SCRIPT}
-    [Teardown]  Run Keyword
-    ...    Remove File           ${SCRIPT}
-    ${code}=  Catenate
-    ...  \#!/bin/sh\n
-    ...  echo ${TEXT}\n
-    Create File                  ${SCRIPT}  ${code}
-    Should Exist                 ${SCRIPT}
-    Command Should Succeed       chmod +x ${SCRIPT}
+    [Setup]    Run Keyword
+    ...    Should Not Exist    ${SCRIPT}
+    ${code}=    Catenate
+    ...    \#!/bin/sh\n
+    ...    echo ${TEXT}\n
+    Create File    ${SCRIPT}    ${code}
+    Should Exist    ${SCRIPT}
+    Command Should Succeed    chmod +x ${SCRIPT}
     File Should Be Executable    ${SCRIPT}
-    ${rc}  ${output}  Run And Return Rc And Output  ${SCRIPT}
-    Should Be Equal As Integers  ${rc}  0
-    Should Match  ${output}  ${TEXT}
+    ${rc}    ${output}=    Run And Return Rc And Output    ${SCRIPT}
+    Should Be Equal As Integers    ${rc}    0
+    Should Match    ${output}    ${TEXT}
+    [Teardown]    Run Keyword
+    ...    Remove File    ${SCRIPT}
+
+*** Keywords ***
+Setup
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+
+Teardown
+    Remove Volume    ${VOLUME}    path=${TESTPATH}
+    Logout

--- a/tests/workload/dir.robot
+++ b/tests/workload/dir.robot
@@ -1,38 +1,40 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Directory Object tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup
-Suite Teardown    Teardown
+Documentation       Directory Object tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup
+Suite Teardown      Teardown
 
 *** Variables ***
-${VOLUME}      test.basic
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
-${NAME}        \u20ac\u2020\u2021
-${FILE}        ${TESTPATH}/${NAME}
-
-*** Keywords ***
-Setup
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume  ${VOLUME}  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}  acl=system:anyuser,read
-
-Teardown
-    Remove Volume  ${VOLUME}  path=${TESTPATH}
-    Logout
+${VOLUME}       test.basic
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
+${NAME}         \u20ac\u2020\u2021
+${FILE}         ${TESTPATH}/${NAME}
 
 *** Test Cases ***
 Unicode File Name
-    [Setup]  Run Keyword
+    [Setup]    Run Keyword
     ...    Should Not Exist    ${FILE}
-    [Teardown]  Run Keywords
-    ...    Remove File         ${FILE}  AND
+    Create File    ${FILE}    Hello world!    UTF-8
+    Should Exist    ${FILE}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
     ...    Should Not Exist    ${FILE}
-    Create File                ${FILE}    Hello world!   UTF-8
-    Should Exist               ${FILE}
 
+*** Keywords ***
+Setup
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+
+Teardown
+    Remove Volume    ${VOLUME}    path=${TESTPATH}
+    Logout

--- a/tests/workload/dir.robot
+++ b/tests/workload/dir.robot
@@ -22,19 +22,19 @@ ${FILE}         ${TESTPATH}/${NAME}
 
 *** Test Cases ***
 Unicode File Name
-    [Setup]    Run Keyword
-    ...    Should Not Exist    ${FILE}
-    Create File    ${FILE}    Hello world!    UTF-8
-    Should Exist    ${FILE}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Setup]      | Run Keyword
+|  | ...          | Should Not Exist | ${FILE}
+|  | Create File  | ${FILE}          | Hello world! | UTF-8
+|  | Should Exist | ${FILE}
+|  | [Teardown]   | Run Keywords
+|  | ...          | Remove File      | ${FILE}      | AND
+|  | ...          | Should Not Exist | ${FILE}
 
 *** Keywords ***
 Setup
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+|  | Login         | ${AFS_ADMIN} | keytab=${AFS_ADMIN_KEYTAB}
+|  | Create Volume | ${VOLUME}    | server=${SERVER}           | part=${PARTITION} | path=${TESTPATH} | acl=system:anyuser,read
 
 Teardown
-    Remove Volume    ${VOLUME}    path=${TESTPATH}
-    Logout
+|  | Remove Volume | ${VOLUME} | path=${TESTPATH}
+|  | Logout

--- a/tests/workload/find.robot
+++ b/tests/workload/find.robot
@@ -33,15 +33,7 @@ Traverse Tree with Two Parents
 *** Keywords ***
 Create Tree
 |  | [Documentation] | Create a simple file tree hierarchy.
-|  | ...             | :
-|  | ...             | :                                    | /
-|  | ...             | :                                    | :-- v0
-|  | ...             | :                                    | :                | `-- v3
-|  | ...             | :                                    | :                | `-- file1
-|  | ...             | :                                    | :-- v1
-|  | ...             | :                                    | `-- v2
-|  | ...             | :                                    | `-- file2
-|  | ...             | :
+|  | ...             |
 |  | Create Volume   | ${VOLUME}                            | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}
 |  | Create Volume   | ${VOLUME}.0                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v0
 |  | Create Volume   | ${VOLUME}.1                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v1
@@ -53,17 +45,6 @@ Create Tree
 Create Tree With Two Parents
 |  | [Documentation]        | Add a second mount point to volume 3 so it
 |  | ...                    | will have two parents in the hierarchy.
-|  | ...                    | :
-|  | ...                    | :                                                  | /
-|  | ...                    | :                                                  | :-- v0
-|  | ...                    | :                                                  | :         | `-- v3
-|  | ...                    | :                                                  | :         | `-- file1
-|  | ...                    | :                                                  | :-- v1
-|  | ...                    | :                                                  | :         | `-- v3a
-|  | ...                    | :                                                  | :         | `-- file1
-|  | ...                    | :                                                  | `-- v2
-|  | ...                    | :                                                  | `-- file2
-|  | ...                    | :
 |  | Create Tree
 |  | Command Should Succeed | ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
 

--- a/tests/workload/find.robot
+++ b/tests/workload/find.robot
@@ -15,15 +15,15 @@ ${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
 *** Keywords ***
 Create Tree
     [Documentation]  Create a simple file tree hierarchy.
-    ...  |
-    ...  |     /
-    ...  |     |-- v0
-    ...  |     |   `-- v3
-    ...  |     |       `-- file1
-    ...  |     |-- v1
-    ...  |     `-- v2
-    ...  |         `-- file2
-    ...  |
+    ...  :
+    ...  :     /
+    ...  :     :-- v0
+    ...  :     :   `-- v3
+    ...  :     :       `-- file1
+    ...  :     :-- v1
+    ...  :     `-- v2
+    ...  :         `-- file2
+    ...  :
     Create Volume   ${VOLUME}    server=${SERVER}  part=${PARTITION}  path=${TESTPATH}
     Create Volume   ${VOLUME}.0  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v0
     Create Volume   ${VOLUME}.1  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v1
@@ -35,17 +35,17 @@ Create Tree
 Create Tree With Two Parents
     [Documentation]  Add a second mount point to volume 3 so it
     ...              will have two parents in the hierarchy.
-    ...  |
-    ...  |    /
-    ...  |    |-- v0
-    ...  |    |   `-- v3
-    ...  |    |       `-- file1
-    ...  |    |-- v1
-    ...  |    |   `-- v3a
-    ...  |    |       `-- file1
-    ...  |    `-- v2
-    ...  |        `-- file2
-    ...  |
+    ...  :
+    ...  :    /
+    ...  :    :-- v0
+    ...  :    :   `-- v3
+    ...  :    :       `-- file1
+    ...  :    :-- v1
+    ...  :    :   `-- v3a
+    ...  :    :       `-- file1
+    ...  :    `-- v2
+    ...  :        `-- file2
+    ...  :
     Create Tree
     Command Should Succeed   ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
 

--- a/tests/workload/find.robot
+++ b/tests/workload/find.robot
@@ -1,83 +1,84 @@
 *** Settings ***
-Documentation     File Hierarchy Traversal Tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-Suite Teardown    Logout
+Documentation       File Hierarchy Traversal Tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+Suite Teardown      Logout
 
 *** Variables ***
-${VOLUME}      test.find
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
-
-*** Keywords ***
-Create Tree
-    [Documentation]  Create a simple file tree hierarchy.
-    ...  :
-    ...  :     /
-    ...  :     :-- v0
-    ...  :     :   `-- v3
-    ...  :     :       `-- file1
-    ...  :     :-- v1
-    ...  :     `-- v2
-    ...  :         `-- file2
-    ...  :
-    Create Volume   ${VOLUME}    server=${SERVER}  part=${PARTITION}  path=${TESTPATH}
-    Create Volume   ${VOLUME}.0  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v0
-    Create Volume   ${VOLUME}.1  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v1
-    Create Volume   ${VOLUME}.2  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v2
-    Create Volume   ${VOLUME}.3  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}/v0/v3
-    Create File     ${TESTPATH}/v0/v3/file1  hello world\n
-    Create File     ${TESTPATH}/v2/file2     greetings\n
-
-Create Tree With Two Parents
-    [Documentation]  Add a second mount point to volume 3 so it
-    ...              will have two parents in the hierarchy.
-    ...  :
-    ...  :    /
-    ...  :    :-- v0
-    ...  :    :   `-- v3
-    ...  :    :       `-- file1
-    ...  :    :-- v1
-    ...  :    :   `-- v3a
-    ...  :    :       `-- file1
-    ...  :    `-- v2
-    ...  :        `-- file2
-    ...  :
-    Create Tree
-    Command Should Succeed   ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
-
-Remove Tree
-    Remove File     ${TESTPATH}/v2/file2
-    Remove File     ${TESTPATH}/v0/v3/file1
-    Remove Volume   ${VOLUME}.3  path=${TESTPATH}/v0/v3
-    Remove Volume   ${VOLUME}.2  path=${TESTPATH}/v2
-    Remove Volume   ${VOLUME}.1  path=${TESTPATH}/v1
-    Remove Volume   ${VOLUME}.0  path=${TESTPATH}/v0
-    Remove Volume   ${VOLUME}    path=${TESTPATH}
-
-File Should Be Found
-    [Arguments]    ${target}
-    ${rc}  ${output}    Run And Return Rc And Output    ${GFIND} ${TESTPATH} -noleaf
-    Log    ${output}
-    Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  ${target}
+${VOLUME}       test.find
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***
 Traverse Simple Tree
     [Tags]    requires-gfind
-    [Setup]       Create Tree
-    File Should Be Found     ${TESTPATH}/v0/v3/file1
-    File Should Be Found     ${TESTPATH}/v2/file2
+    [Setup]    Create Tree
+    File Should Be Found    ${TESTPATH}/v0/v3/file1
+    File Should Be Found    ${TESTPATH}/v2/file2
     [Teardown]    Remove Tree
 
 Traverse Tree with Two Parents
     [Tags]    bug    requires-gfind
-    [Setup]       Create Tree With Two Parents
-    File Should Be Found     ${TESTPATH}/v0/v3/file1
-    File Should Be Found     ${TESTPATH}/v1/v3a/file1
-    File Should Be Found     ${TESTPATH}/v2/file2
+    [Setup]    Create Tree With Two Parents
+    File Should Be Found    ${TESTPATH}/v0/v3/file1
+    File Should Be Found    ${TESTPATH}/v1/v3a/file1
+    File Should Be Found    ${TESTPATH}/v2/file2
     [Teardown]    Remove Tree
 
+*** Keywords ***
+Create Tree
+    [Documentation]    Create a simple file tree hierarchy.
+    ...    :
+    ...    :    /
+    ...    :    :-- v0
+    ...    :    :    `-- v3
+    ...    :    :    `-- file1
+    ...    :    :-- v1
+    ...    :    `-- v2
+    ...    :    `-- file2
+    ...    :
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}
+    Create Volume    ${VOLUME}.0    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v0
+    Create Volume    ${VOLUME}.1    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v1
+    Create Volume    ${VOLUME}.2    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v2
+    Create Volume    ${VOLUME}.3    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v0/v3
+    Create File    ${TESTPATH}/v0/v3/file1    hello world\n
+    Create File    ${TESTPATH}/v2/file2    greetings\n
+
+Create Tree With Two Parents
+    [Documentation]    Add a second mount point to volume 3 so it
+    ...    will have two parents in the hierarchy.
+    ...    :
+    ...    :    /
+    ...    :    :-- v0
+    ...    :    :    `-- v3
+    ...    :    :    `-- file1
+    ...    :    :-- v1
+    ...    :    :    `-- v3a
+    ...    :    :    `-- file1
+    ...    :    `-- v2
+    ...    :    `-- file2
+    ...    :
+    Create Tree
+    Command Should Succeed    ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
+
+Remove Tree
+    Remove File    ${TESTPATH}/v2/file2
+    Remove File    ${TESTPATH}/v0/v3/file1
+    Remove Volume    ${VOLUME}.3    path=${TESTPATH}/v0/v3
+    Remove Volume    ${VOLUME}.2    path=${TESTPATH}/v2
+    Remove Volume    ${VOLUME}.1    path=${TESTPATH}/v1
+    Remove Volume    ${VOLUME}.0    path=${TESTPATH}/v0
+    Remove Volume    ${VOLUME}    path=${TESTPATH}
+
+File Should Be Found
+    [Arguments]    ${target}
+    ${rc}    ${output}    Run And Return Rc And Output    ${GFIND} ${TESTPATH} -noleaf
+    Log    ${output}
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${output}    ${target}

--- a/tests/workload/find.robot
+++ b/tests/workload/find.robot
@@ -16,69 +16,69 @@ ${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
 
 *** Test Cases ***
 Traverse Simple Tree
-    [Tags]    requires-gfind
-    [Setup]    Create Tree
-    File Should Be Found    ${TESTPATH}/v0/v3/file1
-    File Should Be Found    ${TESTPATH}/v2/file2
-    [Teardown]    Remove Tree
+|  | [Tags]               | requires-gfind
+|  | [Setup]              | Create Tree
+|  | File Should Be Found | ${TESTPATH}/v0/v3/file1
+|  | File Should Be Found | ${TESTPATH}/v2/file2
+|  | [Teardown]           | Remove Tree
 
 Traverse Tree with Two Parents
-    [Tags]    bug    requires-gfind
-    [Setup]    Create Tree With Two Parents
-    File Should Be Found    ${TESTPATH}/v0/v3/file1
-    File Should Be Found    ${TESTPATH}/v1/v3a/file1
-    File Should Be Found    ${TESTPATH}/v2/file2
-    [Teardown]    Remove Tree
+|  | [Tags]               | bug                          | requires-gfind
+|  | [Setup]              | Create Tree With Two Parents
+|  | File Should Be Found | ${TESTPATH}/v0/v3/file1
+|  | File Should Be Found | ${TESTPATH}/v1/v3a/file1
+|  | File Should Be Found | ${TESTPATH}/v2/file2
+|  | [Teardown]           | Remove Tree
 
 *** Keywords ***
 Create Tree
-    [Documentation]    Create a simple file tree hierarchy.
-    ...    :
-    ...    :    /
-    ...    :    :-- v0
-    ...    :    :    `-- v3
-    ...    :    :    `-- file1
-    ...    :    :-- v1
-    ...    :    `-- v2
-    ...    :    `-- file2
-    ...    :
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}
-    Create Volume    ${VOLUME}.0    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v0
-    Create Volume    ${VOLUME}.1    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v1
-    Create Volume    ${VOLUME}.2    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v2
-    Create Volume    ${VOLUME}.3    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}/v0/v3
-    Create File    ${TESTPATH}/v0/v3/file1    hello world\n
-    Create File    ${TESTPATH}/v2/file2    greetings\n
+|  | [Documentation] | Create a simple file tree hierarchy.
+|  | ...             | :
+|  | ...             | :                                    | /
+|  | ...             | :                                    | :-- v0
+|  | ...             | :                                    | :                | `-- v3
+|  | ...             | :                                    | :                | `-- file1
+|  | ...             | :                                    | :-- v1
+|  | ...             | :                                    | `-- v2
+|  | ...             | :                                    | `-- file2
+|  | ...             | :
+|  | Create Volume   | ${VOLUME}                            | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}
+|  | Create Volume   | ${VOLUME}.0                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v0
+|  | Create Volume   | ${VOLUME}.1                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v1
+|  | Create Volume   | ${VOLUME}.2                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v2
+|  | Create Volume   | ${VOLUME}.3                          | server=${SERVER} | part=${PARTITION} | path=${TESTPATH}/v0/v3
+|  | Create File     | ${TESTPATH}/v0/v3/file1              | hello world\n
+|  | Create File     | ${TESTPATH}/v2/file2                 | greetings\n
 
 Create Tree With Two Parents
-    [Documentation]    Add a second mount point to volume 3 so it
-    ...    will have two parents in the hierarchy.
-    ...    :
-    ...    :    /
-    ...    :    :-- v0
-    ...    :    :    `-- v3
-    ...    :    :    `-- file1
-    ...    :    :-- v1
-    ...    :    :    `-- v3a
-    ...    :    :    `-- file1
-    ...    :    `-- v2
-    ...    :    `-- file2
-    ...    :
-    Create Tree
-    Command Should Succeed    ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
+|  | [Documentation]        | Add a second mount point to volume 3 so it
+|  | ...                    | will have two parents in the hierarchy.
+|  | ...                    | :
+|  | ...                    | :                                                  | /
+|  | ...                    | :                                                  | :-- v0
+|  | ...                    | :                                                  | :         | `-- v3
+|  | ...                    | :                                                  | :         | `-- file1
+|  | ...                    | :                                                  | :-- v1
+|  | ...                    | :                                                  | :         | `-- v3a
+|  | ...                    | :                                                  | :         | `-- file1
+|  | ...                    | :                                                  | `-- v2
+|  | ...                    | :                                                  | `-- file2
+|  | ...                    | :
+|  | Create Tree
+|  | Command Should Succeed | ${FS} mkm -dir ${TESTPATH}/v1/v3a -vol ${VOLUME}.3
 
 Remove Tree
-    Remove File    ${TESTPATH}/v2/file2
-    Remove File    ${TESTPATH}/v0/v3/file1
-    Remove Volume    ${VOLUME}.3    path=${TESTPATH}/v0/v3
-    Remove Volume    ${VOLUME}.2    path=${TESTPATH}/v2
-    Remove Volume    ${VOLUME}.1    path=${TESTPATH}/v1
-    Remove Volume    ${VOLUME}.0    path=${TESTPATH}/v0
-    Remove Volume    ${VOLUME}    path=${TESTPATH}
+|  | Remove File   | ${TESTPATH}/v2/file2
+|  | Remove File   | ${TESTPATH}/v0/v3/file1
+|  | Remove Volume | ${VOLUME}.3             | path=${TESTPATH}/v0/v3
+|  | Remove Volume | ${VOLUME}.2             | path=${TESTPATH}/v2
+|  | Remove Volume | ${VOLUME}.1             | path=${TESTPATH}/v1
+|  | Remove Volume | ${VOLUME}.0             | path=${TESTPATH}/v0
+|  | Remove Volume | ${VOLUME}               | path=${TESTPATH}
 
 File Should Be Found
-    [Arguments]    ${target}
-    ${rc}    ${output}    Run And Return Rc And Output    ${GFIND} ${TESTPATH} -noleaf
-    Log    ${output}
-    Should Be Equal As Integers    ${rc}    0
-    Should Contain    ${output}    ${target}
+|  | [Arguments]                 | ${target}
+|  | ${rc}                       | ${output} | Run And Return Rc And Output | ${GFIND} ${TESTPATH} -noleaf
+|  | Log                         | ${output}
+|  | Should Be Equal As Integers | ${rc}     | 0
+|  | Should Contain              | ${output} | ${target}

--- a/tests/workload/hugefile.robot
+++ b/tests/workload/hugefile.robot
@@ -1,71 +1,74 @@
+*** Comments ***
 # Copyright (c) 2015, 2020 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Regression
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup
-Suite Teardown    Teardown
+Documentation       Regression
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup
+Suite Teardown      Teardown
 
 *** Variables ***
-${VOLUME}      test.basic
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${TESTPATH}    /afs/.${AFS_CELL}/test/${VOLUME}
-${FILE}        ${TESTPATH}/file
-
-*** Keywords ***
-Setup
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume  ${VOLUME}  server=${SERVER}  part=${PARTITION}  path=${TESTPATH}  acl=system:anyuser,read
-
-Teardown
-    Remove Volume  ${VOLUME}  path=${TESTPATH}
-    Logout
+${VOLUME}       test.basic
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
+${FILE}         ${TESTPATH}/file
 
 *** Test Cases ***
 Create a Larger Than 2gb File
-    [Tags]  slow
-    [Setup]  Run Keyword
-    ...    Create File                    ${FILE}
-    Should Exist                   ${FILE}
-    ${output}=  Run                dd if=/dev/zero of=${FILE} bs=1024 count=2M
-    [Teardown]  Run Keywords
-    ...    Remove File                    ${FILE}  AND
-    ...    Should Not Exist               ${FILE}
+    [Tags]    slow
+    [Setup]    Run Keyword
+    ...    Create File    ${FILE}
+    Should Exist    ${FILE}
+    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=2M
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Write a File Larger than the Cache
-    [Tags]  slow
-    [Setup]  Run Keywords
-    ...    Should Not Exist               ${FILE}  AND
-    ...    Create File                    ${FILE}
-    ${size}=  Get Cache Size
-    Should Exist                   ${FILE}
-    ${output}=  Run                dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
-    [Teardown]  Run Keywords
-    ...    Remove File                    ${FILE}  AND
-    ...    Should Not Exist               ${FILE}
+    [Tags]    slow
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE}    AND
+    ...    Create File    ${FILE}
+    ${size}=    Get Cache Size
+    Should Exist    ${FILE}
+    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Read a File Larger than the Cache
-    [Tags]  slow
-    [Setup]  Run Keywords
-    ...    Should Not Exist               ${FILE}  AND
-    ...    Create File                    ${FILE}
-    ${size}=  Get Cache Size
-    Should Exist                   ${FILE}
-    ${output}=  Run                dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
-    Should Not Contain             ${FILE}  0
-    [Teardown]  Run Keywords
-    ...    Remove File                    ${FILE}  AND
-    ...    Should Not Exist               ${FILE}
+    [Tags]    slow
+    [Setup]    Run Keywords
+    ...    Should Not Exist    ${FILE}    AND
+    ...    Create File    ${FILE}
+    ${size}=    Get Cache Size
+    Should Exist    ${FILE}
+    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
+    Should Not Contain    ${FILE}    0
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
 
 Read Write a File Larger than 4G
-    [Tags]  slow
-    [Setup]  Run Keywords
-    Command Should Succeed  dd if=/dev/urandom of=${FILE} bs=1024 count=5M
-    Command Should Succeed  dd if=${FILE} of=/dev/null
-    [Teardown]  Run Keywords
-    ...    Remove File                    ${FILE}  AND
-    ...    Should Not Exist               ${FILE}
+    [Tags]    slow
+    [Setup]    Run Keywords
+    Command Should Succeed    dd if=/dev/urandom of=${FILE} bs=1024 count=5M
+    Command Should Succeed    dd if=${FILE} of=/dev/null
+    [Teardown]    Run Keywords
+    ...    Remove File    ${FILE}    AND
+    ...    Should Not Exist    ${FILE}
+
+*** Keywords ***
+Setup
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+
+Teardown
+    Remove Volume    ${VOLUME}    path=${TESTPATH}
+    Logout

--- a/tests/workload/hugefile.robot
+++ b/tests/workload/hugefile.robot
@@ -21,54 +21,54 @@ ${FILE}         ${TESTPATH}/file
 
 *** Test Cases ***
 Create a Larger Than 2gb File
-    [Tags]    slow
-    [Setup]    Run Keyword
-    ...    Create File    ${FILE}
-    Should Exist    ${FILE}
-    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=2M
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Tags]       | slow
+|  | [Setup]      | Run Keyword
+|  | ...          | Create File      | ${FILE}
+|  | Should Exist | ${FILE}
+|  | ${output}=   | Run              | dd if=/dev/zero of=${FILE} bs=1024 count=2M
+|  | [Teardown]   | Run Keywords
+|  | ...          | Remove File      | ${FILE}                                     | AND
+|  | ...          | Should Not Exist | ${FILE}
 
 Write a File Larger than the Cache
-    [Tags]    slow
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE}    AND
-    ...    Create File    ${FILE}
-    ${size}=    Get Cache Size
-    Should Exist    ${FILE}
-    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Tags]       | slow
+|  | [Setup]      | Run Keywords
+|  | ...          | Should Not Exist | ${FILE}                                            | AND
+|  | ...          | Create File      | ${FILE}
+|  | ${size}=     | Get Cache Size
+|  | Should Exist | ${FILE}
+|  | ${output}=   | Run              | dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
+|  | [Teardown]   | Run Keywords
+|  | ...          | Remove File      | ${FILE}                                            | AND
+|  | ...          | Should Not Exist | ${FILE}
 
 Read a File Larger than the Cache
-    [Tags]    slow
-    [Setup]    Run Keywords
-    ...    Should Not Exist    ${FILE}    AND
-    ...    Create File    ${FILE}
-    ${size}=    Get Cache Size
-    Should Exist    ${FILE}
-    ${output}=    Run    dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
-    Should Not Contain    ${FILE}    0
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Tags]             | slow
+|  | [Setup]            | Run Keywords
+|  | ...                | Should Not Exist | ${FILE}                                            | AND
+|  | ...                | Create File      | ${FILE}
+|  | ${size}=           | Get Cache Size
+|  | Should Exist       | ${FILE}
+|  | ${output}=         | Run              | dd if=/dev/zero of=${FILE} bs=1024 count=${size+1}
+|  | Should Not Contain | ${FILE}          | 0
+|  | [Teardown]         | Run Keywords
+|  | ...                | Remove File      | ${FILE}                                            | AND
+|  | ...                | Should Not Exist | ${FILE}
 
 Read Write a File Larger than 4G
-    [Tags]    slow
-    [Setup]    Run Keywords
-    Command Should Succeed    dd if=/dev/urandom of=${FILE} bs=1024 count=5M
-    Command Should Succeed    dd if=${FILE} of=/dev/null
-    [Teardown]    Run Keywords
-    ...    Remove File    ${FILE}    AND
-    ...    Should Not Exist    ${FILE}
+|  | [Tags]                 | slow
+|  | [Setup]                | Run Keywords
+|  | Command Should Succeed | dd if=/dev/urandom of=${FILE} bs=1024 count=5M
+|  | Command Should Succeed | dd if=${FILE} of=/dev/null
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Remove File                                    | ${FILE} | AND
+|  | ...                    | Should Not Exist                               | ${FILE}
 
 *** Keywords ***
 Setup
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${TESTPATH}    acl=system:anyuser,read
+|  | Login         | ${AFS_ADMIN} | keytab=${AFS_ADMIN_KEYTAB}
+|  | Create Volume | ${VOLUME}    | server=${SERVER}           | part=${PARTITION} | path=${TESTPATH} | acl=system:anyuser,read
 
 Teardown
-    Remove Volume    ${VOLUME}    path=${TESTPATH}
-    Logout
+|  | Remove Volume | ${VOLUME} | path=${TESTPATH}
+|  | Logout

--- a/tests/workload/mountpoint.robot
+++ b/tests/workload/mountpoint.robot
@@ -26,65 +26,65 @@ ${TESTPATH2}    /afs/.${AFS_CELL}/${VOLUME2}
 
 *** Test Cases ***
 Make and Remove a Mountpoint
-    [Setup]    Run Keyword
-    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT} -vol ${VOLUME}
-    Directory Should Exist    ${MTPT}
-    [Teardown]    Run Keywords
-    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT}    AND
-    ...    Directory Should Not Exist    ${MTPT}
+|  | [Setup]                | Run Keyword
+|  | ...                    | Command Should Succeed     | ${FS} mkmount -dir ${MTPT} -vol ${VOLUME}
+|  | Directory Should Exist | ${MTPT}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Command Should Succeed     | ${FS} rmmount -dir ${MTPT}                | AND
+|  | ...                    | Directory Should Not Exist | ${MTPT}
 
 Make and Remove a Mountpoint with Command Aliases
-    [Setup]    Run Keyword
-    ...    Command Should Succeed    ${FS} mkm ${MTPT} root.cell
-    Directory Should Exist    ${MTPT}
-    [Teardown]    Run Keywords
-    ...    Command Should Succeed    ${FS} rmm ${MTPT}    AND
-    ...    Directory Should Not Exist    ${MTPT}
+|  | [Setup]                | Run Keyword
+|  | ...                    | Command Should Succeed     | ${FS} mkm ${MTPT} root.cell
+|  | Directory Should Exist | ${MTPT}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Command Should Succeed     | ${FS} rmm ${MTPT}           | AND
+|  | ...                    | Directory Should Not Exist | ${MTPT}
 
 Create a Mountpoint to a Nonexistent Volume
-    [Documentation]    The fs command permits the creation of dangling mountpoints.
-    ...    A directory entry is created, but the directory is not usable.
-    [Setup]    Run Keyword
-    ...    Command Should Succeed    ${FS} mkm ${MTPT} no-such-volume
-    Directory Entry Should Exist    ${MTPT}
-    Command Should Fail    test -d ${MTPT}
-    Command Should Fail    touch ${MTPT}/foo
-    [Teardown]    Run Keyword
-    ...    Command Should Succeed    ${FS} rmm ${MTPT}
+|  | [Documentation]              | The fs command permits the creation of dangling mountpoints.
+|  | ...                          | A directory entry is created, but the directory is not usable.
+|  | [Setup]                      | Run Keyword
+|  | ...                          | Command Should Succeed                                         | ${FS} mkm ${MTPT} no-such-volume
+|  | Directory Entry Should Exist | ${MTPT}
+|  | Command Should Fail          | test -d ${MTPT}
+|  | Command Should Fail          | touch ${MTPT}/foo
+|  | [Teardown]                   | Run Keyword
+|  | ...                          | Command Should Succeed                                         | ${FS} rmm ${MTPT}
 
 Make and Remove a Mountpoint in root.cell volume
-    [Documentation]    Creating/removing a mountpoint in a root directory.
-    ...    In releases prior to 1.8.x of AFS there was a bug in the
-    ...    cachemanager when removing a mountpoint that is in the root of a volume.
-    [Setup]    Run Keyword
-    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT2} -vol ${VOLUME2}
-    Directory Should Exist    ${MTPT2}
-    [Teardown]    Run Keywords
-    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT2}    AND
-    ...    Directory Should Not Exist    ${MTPT2}
+|  | [Documentation]        | Creating/removing a mountpoint in a root directory.
+|  | ...                    | In releases prior to 1.8.x of AFS there was a bug in the
+|  | ...                    | cachemanager when removing a mountpoint that is in the root of a volume.
+|  | [Setup]                | Run Keyword
+|  | ...                    | Command Should Succeed                                                   | ${FS} mkmount -dir ${MTPT2} -vol ${VOLUME2}
+|  | Directory Should Exist | ${MTPT2}
+|  | [Teardown]             | Run Keywords
+|  | ...                    | Command Should Succeed                                                   | ${FS} rmmount -dir ${MTPT2}                 | AND
+|  | ...                    | Directory Should Not Exist                                               | ${MTPT2}
 
 Create a Mountpoint to a Nonexistent Volume in root.cell volume
-    [Documentation]    The fs command permits the creation of dangling mountpoints.
-    ...    A directory entry is created, but the directory is not usable.
-    ...    Repeating this test in root.cell volume as well.
-    [Setup]    Run Keyword
-    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT4} -vol no-such-volume
-    Directory Entry Should Exist    ${MTPT4}
-    Command Should Fail    test -d ${MTPT4}
-    Command Should Fail    touch ${MTPT4}/foo
-    [Teardown]    Run Keywords
-    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT4}    AND
-    ...    Directory Should Not Exist    ${MTPT4}
+|  | [Documentation]              | The fs command permits the creation of dangling mountpoints.
+|  | ...                          | A directory entry is created, but the directory is not usable.
+|  | ...                          | Repeating this test in root.cell volume as well.
+|  | [Setup]                      | Run Keyword
+|  | ...                          | Command Should Succeed                                         | ${FS} mkmount -dir ${MTPT4} -vol no-such-volume
+|  | Directory Entry Should Exist | ${MTPT4}
+|  | Command Should Fail          | test -d ${MTPT4}
+|  | Command Should Fail          | touch ${MTPT4}/foo
+|  | [Teardown]                   | Run Keywords
+|  | ...                          | Command Should Succeed                                         | ${FS} rmmount -dir ${MTPT4}                     | AND
+|  | ...                          | Directory Should Not Exist                                     | ${MTPT4}
 
 *** Keywords ***
 Setup
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Command Should Succeed    ${VOS} create ${SERVER} ${PARTITION} ${VOLUME}
-    Command Should Succeed    ${VOS} create ${SERVER} ${PARTITION} ${VOLUME2}
-    Add Access Rights    /afs/.${AFS_CELL}    system:authuser    rlidwk
-    Access Control List Contains    /afs/.${AFS_CELL}    system:authuser    rlidwk
+|  | Login                        | ${AFS_ADMIN}                                    | keytab=${AFS_ADMIN_KEYTAB}
+|  | Command Should Succeed       | ${VOS} create ${SERVER} ${PARTITION} ${VOLUME}
+|  | Command Should Succeed       | ${VOS} create ${SERVER} ${PARTITION} ${VOLUME2}
+|  | Add Access Rights            | /afs/.${AFS_CELL}                               | system:authuser            | rlidwk
+|  | Access Control List Contains | /afs/.${AFS_CELL}                               | system:authuser            | rlidwk
 
 Teardown
-    Remove Volume    ${VOLUME}
-    Remove Volume    ${VOLUME2}
-    Logout
+|  | Remove Volume | ${VOLUME}
+|  | Remove Volume | ${VOLUME2}
+|  | Logout

--- a/tests/workload/mountpoint.robot
+++ b/tests/workload/mountpoint.robot
@@ -1,87 +1,90 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Mountpoint tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup
-Suite Teardown    Teardown
+Documentation       Mountpoint tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup
+Suite Teardown      Teardown
 
 *** Variables ***
-${MTPT}           /afs/.${AFS_CELL}/test/mtpt
-${MTPT2}          /afs/.${AFS_CELL}/mtpt2
-${MTPT3}          /afs/.${AFS_CELL}/mtpt3
-${MTPT4}          /afs/.${AFS_CELL}/mtpt4
-${VOLUME}         test.mtpt
-${VOLUME2}        test2.mtpt
-${PARTITION}      a
-${SERVER}         ${AFS_FILESERVER_A}
-${TESTPATH}       /afs/.${AFS_CELL}/test/${VOLUME}
-${TESTPATH2}      /afs/.${AFS_CELL}/${VOLUME2}
+${MTPT}         /afs/.${AFS_CELL}/test/mtpt
+${MTPT2}        /afs/.${AFS_CELL}/mtpt2
+${MTPT3}        /afs/.${AFS_CELL}/mtpt3
+${MTPT4}        /afs/.${AFS_CELL}/mtpt4
+${VOLUME}       test.mtpt
+${VOLUME2}      test2.mtpt
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${TESTPATH}     /afs/.${AFS_CELL}/test/${VOLUME}
+${TESTPATH2}    /afs/.${AFS_CELL}/${VOLUME2}
 
 *** Test Cases ***
 Make and Remove a Mountpoint
     [Setup]    Run Keyword
-    ...    Command Should Succeed  ${FS} mkmount -dir ${MTPT} -vol ${VOLUME}
-    Directory Should Exist  ${MTPT}
-    [Teardown]  Run Keywords
-    ...    Command Should Succeed  ${FS} rmmount -dir ${MTPT}  AND
-    ...    Directory Should Not Exist  ${MTPT}
+    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT} -vol ${VOLUME}
+    Directory Should Exist    ${MTPT}
+    [Teardown]    Run Keywords
+    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT}    AND
+    ...    Directory Should Not Exist    ${MTPT}
 
 Make and Remove a Mountpoint with Command Aliases
     [Setup]    Run Keyword
-    ...    Command Should Succeed  ${FS} mkm ${MTPT} root.cell
-    Directory Should Exist  ${MTPT}
-    [Teardown]  Run Keywords
-    ...    Command Should Succeed  ${FS} rmm ${MTPT}  AND
-    ...    Directory Should Not Exist  ${MTPT}
+    ...    Command Should Succeed    ${FS} mkm ${MTPT} root.cell
+    Directory Should Exist    ${MTPT}
+    [Teardown]    Run Keywords
+    ...    Command Should Succeed    ${FS} rmm ${MTPT}    AND
+    ...    Directory Should Not Exist    ${MTPT}
 
 Create a Mountpoint to a Nonexistent Volume
-    [Documentation]   The fs command permits the creation of dangling mountpoints.
-    ...               A directory entry is created, but the directory is not usable.
+    [Documentation]    The fs command permits the creation of dangling mountpoints.
+    ...    A directory entry is created, but the directory is not usable.
     [Setup]    Run Keyword
-    ...    Command Should Succeed        ${FS} mkm ${MTPT} no-such-volume
-    Directory Entry Should Exist  ${MTPT}
-    Command Should Fail           test -d ${MTPT}
-    Command Should Fail           touch ${MTPT}/foo
+    ...    Command Should Succeed    ${FS} mkm ${MTPT} no-such-volume
+    Directory Entry Should Exist    ${MTPT}
+    Command Should Fail    test -d ${MTPT}
+    Command Should Fail    touch ${MTPT}/foo
     [Teardown]    Run Keyword
-    ...    Command Should Succeed        ${FS} rmm ${MTPT}
+    ...    Command Should Succeed    ${FS} rmm ${MTPT}
 
 Make and Remove a Mountpoint in root.cell volume
-    [Documentation]   Creating/removing a mountpoint in a root directory.
-    ...               In releases prior to 1.8.x of AFS there was a bug in the
-    ...               cachemanager when removing a mountpoint that is in the root of a volume.
+    [Documentation]    Creating/removing a mountpoint in a root directory.
+    ...    In releases prior to 1.8.x of AFS there was a bug in the
+    ...    cachemanager when removing a mountpoint that is in the root of a volume.
     [Setup]    Run Keyword
-    ...    Command Should Succeed  ${FS} mkmount -dir ${MTPT2} -vol ${VOLUME2}
-    Directory Should Exist  ${MTPT2}
-    [Teardown]  Run Keywords
-    ...    Command Should Succeed  ${FS} rmmount -dir ${MTPT2}  AND
-    ...    Directory Should Not Exist  ${MTPT2}
+    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT2} -vol ${VOLUME2}
+    Directory Should Exist    ${MTPT2}
+    [Teardown]    Run Keywords
+    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT2}    AND
+    ...    Directory Should Not Exist    ${MTPT2}
 
 Create a Mountpoint to a Nonexistent Volume in root.cell volume
-    [Documentation]   The fs command permits the creation of dangling mountpoints.
-    ...               A directory entry is created, but the directory is not usable.
-    ...               Repeating this test in root.cell volume as well.
+    [Documentation]    The fs command permits the creation of dangling mountpoints.
+    ...    A directory entry is created, but the directory is not usable.
+    ...    Repeating this test in root.cell volume as well.
     [Setup]    Run Keyword
-    ...    Command Should Succeed        ${FS} mkmount -dir ${MTPT4} -vol no-such-volume
-    Directory Entry Should Exist  ${MTPT4}
-    Command Should Fail           test -d ${MTPT4}
-    Command Should Fail           touch ${MTPT4}/foo
+    ...    Command Should Succeed    ${FS} mkmount -dir ${MTPT4} -vol no-such-volume
+    Directory Entry Should Exist    ${MTPT4}
+    Command Should Fail    test -d ${MTPT4}
+    Command Should Fail    touch ${MTPT4}/foo
     [Teardown]    Run Keywords
-    ...    Command Should Succeed        ${FS} rmmount -dir ${MTPT4}  AND
-    ...    Directory Should Not Exist  ${MTPT4}
+    ...    Command Should Succeed    ${FS} rmmount -dir ${MTPT4}    AND
+    ...    Directory Should Not Exist    ${MTPT4}
 
 *** Keywords ***
 Setup
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Command Should Succeed  ${VOS} create ${SERVER} ${PARTITION} ${VOLUME}
-    Command Should Succeed  ${VOS} create ${SERVER} ${PARTITION} ${VOLUME2}
-    Add Access Rights  /afs/.${AFS_CELL}  system:authuser  rlidwk
-    Access Control List Contains  /afs/.${AFS_CELL}  system:authuser  rlidwk
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Command Should Succeed    ${VOS} create ${SERVER} ${PARTITION} ${VOLUME}
+    Command Should Succeed    ${VOS} create ${SERVER} ${PARTITION} ${VOLUME2}
+    Add Access Rights    /afs/.${AFS_CELL}    system:authuser    rlidwk
+    Access Control List Contains    /afs/.${AFS_CELL}    system:authuser    rlidwk
 
 Teardown
-    Remove Volume  ${VOLUME}
-    Remove Volume  ${VOLUME2}
+    Remove Volume    ${VOLUME}
+    Remove Volume    ${VOLUME2}
     Logout

--- a/tests/workload/pag.robot
+++ b/tests/workload/pag.robot
@@ -14,11 +14,11 @@ ${PRINT_GROUPS}     ${PYTHON} -c 'import sys; import os; sys.stdout.write("%s\\n
 
 *** Test Cases ***
 Obtain a PAG with pagsh
-    [Documentation]    Run a pagsh as a child process verify a PAG is set.
-    [Setup]    Run Keyword
-    ...    PAG Should Not Exist
-    ${gids}=    PAG Shell    ${PRINT_GROUPS}
-    ${pag}=    PAG From Groups    ${gids}
-    PAG Should Be Valid    ${pag}
-    [Teardown]    Run Keywords
-    ...    PAG Should Not Exist
+|  | [Documentation]     | Run a pagsh as a child process verify a PAG is set.
+|  | [Setup]             | Run Keyword
+|  | ...                 | PAG Should Not Exist
+|  | ${gids}=            | PAG Shell                                           | ${PRINT_GROUPS}
+|  | ${pag}=             | PAG From Groups                                     | ${gids}
+|  | PAG Should Be Valid | ${pag}
+|  | [Teardown]          | Run Keywords
+|  | ...                 | PAG Should Not Exist

--- a/tests/workload/pag.robot
+++ b/tests/workload/pag.robot
@@ -1,23 +1,24 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     AFS PAG tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
+Documentation       AFS PAG tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
 
 *** Variables ***
-${PRINT_GROUPS}    ${PYTHON} -c 'import sys; import os; sys.stdout.write("%s\\n" % os.getgroups())'
+${PRINT_GROUPS}     ${PYTHON} -c 'import sys; import os; sys.stdout.write("%s\\n" % os.getgroups())'
 
 *** Test Cases ***
 Obtain a PAG with pagsh
-    [Documentation]   Run a pagsh as a child process verify a PAG is set.
-    [Setup]  Run Keyword
+    [Documentation]    Run a pagsh as a child process verify a PAG is set.
+    [Setup]    Run Keyword
     ...    PAG Should Not Exist
-    ${gids}=    PAG Shell          ${PRINT_GROUPS}
-    ${pag}=     PAG From Groups    ${gids}
-    PAG Should Be Valid            ${pag}
-    [Teardown]  Run Keywords
+    ${gids}=    PAG Shell    ${PRINT_GROUPS}
+    ${pag}=    PAG From Groups    ${gids}
+    PAG Should Be Valid    ${pag}
+    [Teardown]    Run Keywords
     ...    PAG Should Not Exist
-

--- a/tests/workload/readonly.robot
+++ b/tests/workload/readonly.robot
@@ -1,30 +1,32 @@
 *** Settings ***
-Documentation     Read-only tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
-Suite Setup       Setup Test Suite
-Suite Teardown    Teardown Test Suite
+Documentation       Read-only tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
+
+Suite Setup         Setup Test Suite
+Suite Teardown      Teardown Test Suite
 
 *** Variables ***
-${VOLUME}      test.ro
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${RWPATH}      /afs/.${AFS_CELL}/test/readonly
-${ROPATH}      /afs/${AFS_CELL}/test/readonly
-
-*** Keywords ***
-Setup Test Suite
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume   ${VOLUME}  server=${SERVER}  part=${PARTITION}  path=${RWPATH}  ro=True  acl=system:anyuser,read
-
-Teardown Test Suite
-    Remove Volume   ${VOLUME}  path=${RWPATH}
-    Logout
+${VOLUME}       test.ro
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${RWPATH}       /afs/.${AFS_CELL}/test/readonly
+${ROPATH}       /afs/${AFS_CELL}/test/readonly
 
 *** Test Cases ***
 Write a File in a Read-only Volume
     [Tags]    requires-multi-fs
     Run Keyword And Expect Error
-    ...  *Read-only file system*
-    ...  Create File  ${ROPATH}/should-be-read-only
+    ...    *Read-only file system*
+    ...    Create File    ${ROPATH}/should-be-read-only
+
+*** Keywords ***
+Setup Test Suite
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${RWPATH}    ro=True    acl=system:anyuser,read
+
+Teardown Test Suite
+    Remove Volume    ${VOLUME}    path=${RWPATH}
+    Logout

--- a/tests/workload/readonly.robot
+++ b/tests/workload/readonly.robot
@@ -17,16 +17,16 @@ ${ROPATH}       /afs/${AFS_CELL}/test/readonly
 
 *** Test Cases ***
 Write a File in a Read-only Volume
-    [Tags]    requires-multi-fs
-    Run Keyword And Expect Error
-    ...    *Read-only file system*
-    ...    Create File    ${ROPATH}/should-be-read-only
+|  | [Tags]                       | requires-multi-fs
+|  | Run Keyword And Expect Error
+|  | ...                          | *Read-only file system*
+|  | ...                          | Create File             | ${ROPATH}/should-be-read-only
 
 *** Keywords ***
 Setup Test Suite
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${RWPATH}    ro=True    acl=system:anyuser,read
+|  | Login         | ${AFS_ADMIN} | keytab=${AFS_ADMIN_KEYTAB}
+|  | Create Volume | ${VOLUME}    | server=${SERVER}           | part=${PARTITION} | path=${RWPATH} | ro=True | acl=system:anyuser,read
 
 Teardown Test Suite
-    Remove Volume    ${VOLUME}    path=${RWPATH}
-    Logout
+|  | Remove Volume | ${VOLUME} | path=${RWPATH}
+|  | Logout

--- a/tests/workload/stress.robot
+++ b/tests/workload/stress.robot
@@ -17,16 +17,16 @@ ${RWPATH}       /afs/.${AFS_CELL}/test/stress
 
 *** Test Cases ***
 Create a Large Number of Entries in a Directory
-    [Tags]    slow
-    [Setup]    Create Stress Test Volume
-    Create Files    ${RWPATH}    31707    0
-    [Teardown]    Remove Stress Test Volume
+|  | [Tags]       | slow
+|  | [Setup]      | Create Stress Test Volume
+|  | Create Files | ${RWPATH}                 | 31707 | 0
+|  | [Teardown]   | Remove Stress Test Volume
 
 *** Keywords ***
 Create Stress Test Volume
-    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${RWPATH}    ro=True    acl=system:anyuser,read
+|  | Login         | ${AFS_ADMIN} | keytab=${AFS_ADMIN_KEYTAB}
+|  | Create Volume | ${VOLUME}    | server=${SERVER}           | part=${PARTITION} | path=${RWPATH} | ro=True | acl=system:anyuser,read
 
 Remove Stress Test Volume
-    Remove Volume    ${VOLUME}    path=${RWPATH}
-    Logout
+|  | Remove Volume | ${VOLUME} | path=${RWPATH}
+|  | Logout

--- a/tests/workload/stress.robot
+++ b/tests/workload/stress.robot
@@ -1,30 +1,32 @@
+*** Comments ***
 # Copyright (c) 2015 Sine Nomine Associates
 # See LICENSE
 
 *** Settings ***
-Documentation     Client stess tests
-Library           OperatingSystem
-Library           String
-Library           OpenAFSLibrary
+Documentation       Client stess tests
+
+Library             OperatingSystem
+Library             String
+Library             OpenAFSLibrary
 
 *** Variables ***
-${VOLUME}      test.stress
-${PARTITION}   a
-${SERVER}      ${AFS_FILESERVER_A}
-${RWPATH}      /afs/.${AFS_CELL}/test/stress
-
-*** Keywords ***
-Create Stress Test Volume
-    Login  ${AFS_ADMIN}  keytab=${AFS_ADMIN_KEYTAB}
-    Create Volume   ${VOLUME}  server=${SERVER}  part=${PARTITION}  path=${RWPATH}  ro=True  acl=system:anyuser,read
-
-Remove Stress Test Volume
-    Remove Volume   ${VOLUME}  path=${RWPATH}
-    Logout
+${VOLUME}       test.stress
+${PARTITION}    a
+${SERVER}       ${AFS_FILESERVER_A}
+${RWPATH}       /afs/.${AFS_CELL}/test/stress
 
 *** Test Cases ***
 Create a Large Number of Entries in a Directory
-    [Tags]  slow
-    [Setup]       Create Stress Test Volume
+    [Tags]    slow
+    [Setup]    Create Stress Test Volume
+    Create Files    ${RWPATH}    31707    0
     [Teardown]    Remove Stress Test Volume
-    Create Files  ${RWPATH}  31707  0
+
+*** Keywords ***
+Create Stress Test Volume
+    Login    ${AFS_ADMIN}    keytab=${AFS_ADMIN_KEYTAB}
+    Create Volume    ${VOLUME}    server=${SERVER}    part=${PARTITION}    path=${RWPATH}    ro=True    acl=system:anyuser,read
+
+Remove Stress Test Volume
+    Remove Volume    ${VOLUME}    path=${RWPATH}
+    Logout

--- a/tools/robotab.py
+++ b/tools/robotab.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python3
+#
+# robotab - tabulate robot framework test cases
+#
+# Warning: This script does an in-place conversion, and makes no attempt to
+# backup the original file! Make sure your files are backed up/checked in
+# before running this.
+#
+# This is a hack to convert the robot files to pipe separated format with nicer
+# column alignment, which is currently unsupported by robotidy.  Hopefully,
+# future versions of robotidy will make this script obsolete.
+#
+# The robot files must be converted to tab separated tables the first time
+# this is run.
+#
+#    $ robotidy --separator tab tests/
+#    $ tools/robotab.py tests/
+#
+# After the initial conversion, it can be run again to fix column alignments in
+# specific files, or all files in a directory tree.
+#
+#    $ tools/robotab.py tests/path/to/example.robot  # one file
+#    $ tools/robotab.py tests/                       # all .robot files
+#
+
+import os
+import sys
+
+def usage():
+    """
+    Print usage.
+    """
+    print('robotab PATH [PATH ..]')
+    print('')
+    print('where:')
+    print('   PATH is a .robot filename or directory containing .robot files')
+
+
+def tabulate(table):
+    """
+    Add spaces to table elements to align columns.
+    """
+    cw = {}   # column widths
+
+    # Trim leading and trailing whitespace from each element.
+    for i, row in enumerate(table):
+        for j, element in enumerate(row):
+            table[i][j] = element.strip()
+
+    # Find the max element width for each column.
+    for row in table:
+        for j, element in enumerate(row):
+            cw[j] = max(cw.get(j, 0), len(element))
+
+    # Reformat elements to align columns.
+    for i, row in enumerate(table):
+        for j, element in enumerate(row):
+            table[i][j] = ' ' + element.ljust(cw[j]) + ' '
+
+
+def append_table(lines, table):
+    """
+    Append table to output lines as column aligned pipe separated
+    format.
+
+    Note an extra sep is added at the beginning of the line to indicate
+    this is pipe separated format.
+    """
+    tabulate(table)
+    for row in table:
+        lines.append('|' + '|'.join(row).rstrip() + '\n')
+
+
+def reformat(filename):
+    """
+    Reformat a robot file.
+
+    Note that pipe separated format requires the lines to start with a
+    pipe char, so that extra char is removed before spliting the line.
+    """
+    print('Reformatting', filename)
+    table = None            # Current table
+    out_lines = []          # Output lines
+
+    with open(filename) as f:
+        in_lines = f.readlines()
+
+    for line in in_lines:
+        if table is None:
+            if line.startswith('|'):
+                table = [line.replace('|', '', 1).split('|')]
+            elif line.startswith('\t'):
+                table = [line.split('\t')]
+            else:
+                out_lines.append(line)
+        else:
+            if line.startswith('|'):
+                table.append(line.replace('|', '', 1).split('|'))
+            elif line.startswith('\t'):
+                table.append(line.split('\t'))
+            else:
+                append_table(out_lines, table)
+                table = None
+                out_lines.append(line)
+    if table is not None:
+        append_table(out_lines, table)
+
+    with open(filename, 'w') as f:
+        f.writelines(out_lines)
+
+
+def recurse(path):
+    """
+    Find and reformat all the robot files in directory tree.
+    """
+    for dirpath, dirnames, filenames in os.walk(path):
+        for filename in filenames:
+            if filename.endswith('.robot'):
+                filepath = os.path.join(dirpath, filename)
+                reformat(filepath)
+
+
+def main():
+    if len(sys.argv) < 2:
+        usage()
+        return 1
+    for path in sys.argv[1:]:
+        if os.path.isfile(path):
+            reformat(path)
+        elif os.path.isdir(path):
+            recurse(path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Convert the robot files to the pipe separated format style from the original spaces separated style. 

The spaces separated style has been found to be error prone and generally unfun.

The pipe separated format style has been supported since Robot Framework 2.7 so should not effect anyone running a very very old version of RF.