### PR TITLE
Chore/add tox ini

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,7 +24,7 @@ help:
 
 .PHONY: refdocs
 refdocs:
-	python3 testdoc.py >source/tests.rst
+	python3 testdoc.py source/tests.rst
 	python3 librst.py
 
 .PHONY: preview

--- a/docs/testdoc.py
+++ b/docs/testdoc.py
@@ -7,6 +7,7 @@
 #
 
 import os
+import sys
 import ast
 import robot.api.parsing
 
@@ -52,27 +53,29 @@ def walk(topdir):
         sections.append({'name': section, 'suites': suites})
     return sections
 
-def print_heading(name, level=1):
+def print_heading(fp, name, level=1):
     underline = {1: '=', 2: '-', 3: '~'}
-    print(name)
-    print(underline[level] * len(name))
-    print('')
+    fp.write('%s\n' % name)
+    fp.write('%s\n' % (underline[level] * len(name)))
+    fp.write('\n')
 
-def render(sections):
-    print_heading('Tests', 1)
+def render(fp, sections):
+    print_heading(fp, 'Tests', 1)
     for section in sections:
-        print_heading(section['name'], 2)
+        print_heading(fp, section['name'], 2)
         for suite in section['suites']:
-            print_heading(suite['name'], 3)
+            print_heading(fp, suite['name'], 3)
             if suite['doc']:
-                print(suite['doc'])
-                print('')
+                fp.write('%s\n' % suite['doc'])
+                fp.write('\n')
             for test in suite['tests']:
-                print('*', test)
-            print('')
+                fp.write('* %s\n' % test)
+            fp.write('\n')
 
 def main():
-    render(walk('../tests'))
+    output = sys.argv[1]
+    with open(output, 'w') as fp:
+        render(fp, walk('../tests'))
 
 if __name__ == '__main__':
     main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,43 @@
+[tox]
+min_version = 4.0
+envlist = \
+    py3{11,12,13}
+
+[testenv]
+description = Run OpenAFS tests
+deps =
+    robotframework==7.2.2
+setenv = \
+    PYTHONPATH = {toxinidir}/libraries
+commands =
+    robot -A settings/smoketest.args tests/
+
+[testenv:py3{11,12,13}-unit]
+description = Run OpenAFS library unit tests
+deps =
+    pytest==8.3.5
+    robotframework==7.2.2
+setenv = \
+    PYTHONPATH = {toxinidir}/libraries
+commands =
+    pytest -v unittests/
+
+[testenv:lint]
+description = Run static checks
+deps =
+    pylint==3.3.6
+    robotframework==7.2.2
+commands =
+    pylint --disable C0209,C0301,R0903 libraries
+    pylint --disable C0301 tests
+
+[testenv:docs]
+description = Build documentation
+changedir = docs
+deps =
+    robotframework==7.2.2
+    -r docs/requirements.txt
+commands =
+	python3 librst.py
+	python3 testdoc.py source/tests.rst
+    sphinx-build -M html source build

--- a/unittests/test_version.py
+++ b/unittests/test_version.py
@@ -1,0 +1,7 @@
+
+import re
+import OpenAFSLibrary
+
+def test_version():
+    assert hasattr(OpenAFSLibrary, "__version__")
+    assert re.match(r"\d+\.\d+\.\d+", OpenAFSLibrary.__version__)


### PR DESCRIPTION
Add a tox config to test with different versions of python and robotframework and to run library linting and unit tests.