### PR TITLE
OpenAFS version related changes

### DIFF
--- a/suites/001-health-checks/clients.robot
+++ b/suites/001-health-checks/clients.robot
@@ -232,11 +232,11 @@ Binaries exist and can run
     Should Be Equal As Integers    ${rc}    0
     Should Contain    ${output}    Usage: rxdebug
 
-    ${rc}    ${output}=    client1.Run And Return Rc And Output    rxdebug -server localhost -port 7001 -version
-    Log Many    ${rc}    rxdebug version: ${output}
+    ${version_client1}=    client1.Get Version    localhost    7001
+    Log    client1 rxdebug version: ${version_client1}
 
-    ${rc}    ${output}=    client2.Run And Return Rc And Output    rxdebug -server localhost -port 7001 -version
-    Log Many    ${rc}    rxdebug version: ${output}
+    ${version_client2}=    client2.Get Version    localhost    7001
+    Log    client2 rxdebug version: ${version_client2}
 
     # OpenAFS vos command.
     ${rc}    ${output}=    client1.Run And Return Rc And Output    which vos

--- a/suites/001-health-checks/clients.robot
+++ b/suites/001-health-checks/clients.robot
@@ -234,9 +234,11 @@ Binaries exist and can run
 
     ${version_client1}=    client1.Get Version    localhost    7001
     Log    client1 rxdebug version: ${version_client1}
+    Set Suite Metadata   Client1 OpenAFS Version    ${version_client1}
 
     ${version_client2}=    client2.Get Version    localhost    7001
     Log    client2 rxdebug version: ${version_client2}
+    Set Suite Metadata   Client2 OpenAFS Version    ${version_client2}
 
     # OpenAFS vos command.
     ${rc}    ${output}=    client1.Run And Return Rc And Output    which vos

--- a/suites/001-health-checks/servers.robot
+++ b/suites/001-health-checks/servers.robot
@@ -134,14 +134,11 @@ Kerberos KDC is running
 Rxdebug version check
     [Documentation]    Rxdebug version check
 
-    ${rc}    ${output}=    server1.Run And Return Rc And Output    rxdebug -server localhost -port 7002 -version
-    Log Many    ${rc}    rxdebug version (server1): ${output}
-    Should Match Regexp    ${output}    AFS version: OpenAFS
+    ${version_server1}=    server1.Get Version    localhost    7002
+    Log    server1 rxdebug version = ${version_server1}
 
-    ${rc}    ${output}=    server2.Run And Return Rc And Output    rxdebug -server localhost -port 7002 -version
-    Log Many    ${rc}    rxdebug version (server2): ${output}
-    Should Match Regexp    ${output}    AFS version: OpenAFS
+    ${version_server2}=    server2.Get Version    localhost    7002
+    Log    server2 rxdebug version = ${version_server2}
 
-    ${rc}    ${output}=    server3.Run And Return Rc And Output    rxdebug -server localhost -port 7002 -version
-    Log Many    ${rc}    rxdebug version: ${output}
-    Should Match Regexp    ${output}    AFS version: OpenAFS
+    ${version_server3}=    server3.Get Version    localhost    7002
+    Log    server3 rxdebug version = ${version_server3}

--- a/suites/001-health-checks/servers.robot
+++ b/suites/001-health-checks/servers.robot
@@ -136,9 +136,12 @@ Rxdebug version check
 
     ${version_server1}=    server1.Get Version    localhost    7002
     Log    server1 rxdebug version = ${version_server1}
+    Set Suite Metadata   Server1 OpenAFS Version    ${version_server1}
 
     ${version_server2}=    server2.Get Version    localhost    7002
     Log    server2 rxdebug version = ${version_server2}
+    Set Suite Metadata   Server2 OpenAFS Version    ${version_server2}
 
     ${version_server3}=    server3.Get Version    localhost    7002
     Log    server3 rxdebug version = ${version_server3}
+    Set Suite Metadata   Server3 OpenAFS Version    ${version_server3}


### PR DESCRIPTION
In this PR:
- We use Get Version keyword to determine OpenAFS version from the OpenAFS robotest client library
- We display OpenAFS version for both client and server suites in their summary section